### PR TITLE
Remove version restriction from getSegmentVersion()

### DIFF
--- a/src/main/java/org/kapott/hbci/dialog/AbstractRawHBCIDialog.java
+++ b/src/main/java/org/kapott/hbci/dialog/AbstractRawHBCIDialog.java
@@ -187,8 +187,8 @@ public abstract class AbstractRawHBCIDialog implements RawHBCIDialog
     }
     
     /**
-     * Liefert die hoechste bei der Bank verfuegbare Segment-Version fuer das HKTAB.
-     * @param p der Passport.
+     * Liefert die hoechste bei der Bank verfuegbare Segment-Version.
+     * @param ctx der Kontext.
      * @param gvName der Name des Geschaeftsvorfalls.
      * @param defaultVersion die Default-Version, wenn keine gefunden wurde.
      * @return die Segment-Version oder NULL, wenn keine brauchbare Version unterstuetzt wird
@@ -204,14 +204,7 @@ public abstract class AbstractRawHBCIDialog implements RawHBCIDialog
   
       try
       {
-        final Integer i = Integer.valueOf(version);
-        if (i == null)
-          return defaultVersion;
-  
-        if (i.intValue() < 2 || i.intValue() > 5)
-          return defaultVersion;
-  
-        return i;
+        return Integer.valueOf(version);
       } catch (Exception e)
       {
         HBCIUtils.log("invalid segment version: " + version, HBCIUtils.LOG_WARN);

--- a/src/main/java/org/kapott/hbci/dialog/HBCIDialogTanMedia.java
+++ b/src/main/java/org/kapott/hbci/dialog/HBCIDialogTanMedia.java
@@ -74,8 +74,8 @@ public class HBCIDialogTanMedia extends AbstractRawHBCIDialog
     HBCIPassportInternal p = ctx != null ? ctx.getPassport() : null;
     if (p == null || !(p instanceof AbstractPinTanPassport))
       return false;
-      
-    return getSegmentVersion(ctx,GVNAME,null) != null;
+
+    return getSegmentVersion(ctx,GVNAME,0) >= 2;
   }
     
   /**


### PR DESCRIPTION
Allow `AbstractRawHBCIDialog.getSegmentVersion()` to return the actual segment version (if available), removing the restriction to versions between 2 and 5.

The existing `supported()` behavior for `HBCIDialogTanMedia` is preserved (versions `>= 2`). I assume that the upper version limit of 5 is implicit as there is no higher version of `TANMediaListPar` defined in any of the `hbci-*.xml` files.

Fixes #34.