### PR TITLE
HITAB: Bilateral vereinbarte TAN-Medien (closes #39)

### DIFF
--- a/src/main/resources/hbci-300.xml
+++ b/src/main/resources/hbci-300.xml
@@ -2050,6 +2050,7 @@
                 <validvalue>M</validvalue>
                 <validvalue>S</validvalue>
                 <validvalue>A</validvalue>
+                <validvalue>B</validvalue>
             </valids>
             <valids path="status">
                 <validvalue>1</validvalue>


### PR DESCRIPTION
Mit HITAB Segmentversion #5 wurde die neue TAN-Medium-Klasse 'B' (Bilateral vereinbart) eingeführt. Damit können Banken bspw. pushTAN- oder photoTAN-Generatoren auflisten, die nicht der ZKA-TAN-Generator-Spezifikation entsprechen (TAN-Medium-Klasse 'G').

siehe FinTS 3.0, Release 11.05.2017, Management TAN-Medien