### PR TITLE
Zwischensalden werden bei mehrere Camt-Nachrichten pro Buchungstag berücksichtigt

### DIFF
--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200103.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200103.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import javax.xml.bind.JAXB;
 
@@ -32,16 +33,16 @@ import org.kapott.hbci.GV.SepaUtil;
 import org.kapott.hbci.GV_Result.GVRKUms.BTag;
 import org.kapott.hbci.GV_Result.GVRKUms.UmsLine;
 import org.kapott.hbci.manager.HBCIUtils;
+import org.kapott.hbci.sepa.jaxb.camt_052_001_03.BalanceType12Code;
+import org.kapott.hbci.sepa.jaxb.camt_052_001_03.CashBalance3;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_03.AccountIdentification4Choice;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_03.AccountReport12;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_03.ActiveOrHistoricCurrencyAndAmount;
-import org.kapott.hbci.sepa.jaxb.camt_052_001_03.BalanceType12Code;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_03.BankToCustomerAccountReportV03;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_03.BankTransactionCodeStructure4;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_03.BranchAndFinancialInstitutionIdentification5;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_03.CashAccount24;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_03.CashAccount25;
-import org.kapott.hbci.sepa.jaxb.camt_052_001_03.CashBalance3;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_03.CreditDebitCode;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_03.DateAndDateTimeChoice;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_03.Document;
@@ -124,7 +125,7 @@ public class ParseCamt05200103 extends AbstractCamtParser
     /**
      * Erzeugt eine einzelne Umsatzbuchung.
      * @param entry der Entry aus der CAMT-Datei.
-     * @param der aktuelle Saldo vor dieser Buchung.
+     * @param currSaldo der aktuelle Saldo vor dieser Buchung.
      * @return die Umsatzbuchung.
      */
     private UmsLine createLine(ReportEntry3 entry, BigDecimal currSaldo)
@@ -158,6 +159,10 @@ public class ParseCamt05200103 extends AbstractCamtParser
         if (ref != null)
         {
             line.id = trim(ref.getPrtry() != null && ref.getPrtry().size() > 0 ? ref.getPrtry().get(0).getRef() : null);
+            // einige Banken verwenden das Account Servicer Reference als eindeutigen Identifier
+            if(line.id==null) {
+                line.id = Optional.ofNullable(entry.getAcctSvcrRef()).orElse(ref.getAcctSvcrRef());
+            }
             line.endToEndId = trim(ref.getEndToEndId());
             line.mandateId = trim(ref.getMndtId());
         }
@@ -295,28 +300,33 @@ public class ParseCamt05200103 extends AbstractCamtParser
 
         ////////////////////////////////////////////////////////////////
         // Start- un End-Saldo ermitteln
-        final long day = 24 * 60 * 60 * 1000L; 
-        for (CashBalance3 bal:report.getBal())
-        {
-            BalanceType12Code code = bal.getTp().getCdOrPrtry().getCd();
-            
-            // Schluss-Saldo vom Vortag
-            if (code == BalanceType12Code.PRCD)
-            {
-                tag.start.value = new Value(this.checkDebit(bal.getAmt().getValue(),bal.getCdtDbtInd()));
-                tag.start.value.setCurr(bal.getAmt().getCcy());
-                
-                //  Wir erhoehen noch das Datum um einen Tag, damit aus dem
-                // Schlusssaldo des Vortages der Startsaldo des aktuellen Tages wird.
-                tag.start.timestamp = new Date(SepaUtil.toDate(bal.getDt().getDt()).getTime() + day);
+        final long day = 24 * 60 * 60 * 1000L;
+
+        if(report.getBal().size()>0){
+            CashBalance3 firstBal = report.getBal().get(0);
+            BalanceType12Code firstCode = firstBal.getTp().getCdOrPrtry().getCd();
+            if(firstCode == BalanceType12Code.PRCD || firstCode == BalanceType12Code.ITBD) {
+                tag.start.value = new Value(this.checkDebit(firstBal.getAmt().getValue(),firstBal.getCdtDbtInd()));
+                tag.start.value.setCurr(firstBal.getAmt().getCcy());
+                if(firstCode == BalanceType12Code.PRCD){
+                    //  Wir erhoehen noch das Datum um einen Tag, damit aus dem
+                    // Schlusssaldo des Vortages der Startsaldo des aktuellen Tages wird.
+                    tag.start.timestamp = new Date(SepaUtil.toDate(firstBal.getDt().getDt()).getTime() + day);
+                }else{
+                    // bei einem Zwischensaldo ist der Tag derselbe
+                    tag.start.timestamp = new Date(SepaUtil.toDate(firstBal.getDt().getDt()).getTime());
+                }
             }
-            
-            // End-Saldo
-            else if (code == BalanceType12Code.CLBD)
-            {
-                tag.end.value = new Value(this.checkDebit(bal.getAmt().getValue(),bal.getCdtDbtInd()));
-                tag.end.value.setCurr(bal.getAmt().getCcy());
-                tag.end.timestamp = SepaUtil.toDate(bal.getDt().getDt());
+
+            // Zweiter Balance Eintrag ist ein Schlusssaldo oder auch ein Zwischensaldo
+            if(report.getBal().size()>1){
+                CashBalance3 secondBal = report.getBal().get(1);
+                BalanceType12Code secondCode = secondBal.getTp().getCdOrPrtry().getCd();
+                if(secondCode == BalanceType12Code.CLBD || secondCode == BalanceType12Code.ITBD) {
+                    tag.end.value = new Value(this.checkDebit(secondBal.getAmt().getValue(),secondBal.getCdtDbtInd()));
+                    tag.end.value.setCurr(secondBal.getAmt().getCcy());
+                    tag.end.timestamp = SepaUtil.toDate(secondBal.getDt().getDt());
+                }
             }
         }
         //

--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200104.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200104.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import javax.xml.bind.JAXB;
 
@@ -32,16 +33,16 @@ import org.kapott.hbci.GV.SepaUtil;
 import org.kapott.hbci.GV_Result.GVRKUms.BTag;
 import org.kapott.hbci.GV_Result.GVRKUms.UmsLine;
 import org.kapott.hbci.manager.HBCIUtils;
+import org.kapott.hbci.sepa.jaxb.camt_052_001_04.BalanceType12Code;
+import org.kapott.hbci.sepa.jaxb.camt_052_001_04.CashBalance3;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_04.AccountIdentification4Choice;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_04.AccountReport16;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_04.ActiveOrHistoricCurrencyAndAmount;
-import org.kapott.hbci.sepa.jaxb.camt_052_001_04.BalanceType12Code;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_04.BankToCustomerAccountReportV04;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_04.BankTransactionCodeStructure4;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_04.BranchAndFinancialInstitutionIdentification5;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_04.CashAccount24;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_04.CashAccount25;
-import org.kapott.hbci.sepa.jaxb.camt_052_001_04.CashBalance3;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_04.CreditDebitCode;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_04.DateAndDateTimeChoice;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_04.Document;
@@ -124,7 +125,7 @@ public class ParseCamt05200104 extends AbstractCamtParser
     /**
      * Erzeugt eine einzelne Umsatzbuchung.
      * @param entry der Entry aus der CAMT-Datei.
-     * @param der aktuelle Saldo vor dieser Buchung.
+     * @param currSaldo der aktuelle Saldo vor dieser Buchung.
      * @return die Umsatzbuchung.
      */
     private UmsLine createLine(ReportEntry4 entry, BigDecimal currSaldo)
@@ -158,6 +159,10 @@ public class ParseCamt05200104 extends AbstractCamtParser
         if (ref != null)
         {
             line.id = trim(ref.getPrtry() != null && ref.getPrtry().size() > 0 ? ref.getPrtry().get(0).getRef() : null);
+            // einige Banken verwenden das Account Servicer Reference als eindeutigen Identifier
+            if(line.id==null) {
+                line.id = Optional.ofNullable(entry.getAcctSvcrRef()).orElse(ref.getAcctSvcrRef());
+            }
             line.endToEndId = trim(ref.getEndToEndId());
             line.mandateId = trim(ref.getMndtId());
         }
@@ -295,28 +300,32 @@ public class ParseCamt05200104 extends AbstractCamtParser
 
         ////////////////////////////////////////////////////////////////
         // Start- un End-Saldo ermitteln
-        final long day = 24 * 60 * 60 * 1000L; 
-        for (CashBalance3 bal:report.getBal())
-        {
-            BalanceType12Code code = bal.getTp().getCdOrPrtry().getCd();
-            
-            // Schluss-Saldo vom Vortag
-            if (code == BalanceType12Code.PRCD)
-            {
-                tag.start.value = new Value(this.checkDebit(bal.getAmt().getValue(),bal.getCdtDbtInd()));
-                tag.start.value.setCurr(bal.getAmt().getCcy());
-                
-                //  Wir erhoehen noch das Datum um einen Tag, damit aus dem
-                // Schlusssaldo des Vortages der Startsaldo des aktuellen Tages wird.
-                tag.start.timestamp = new Date(SepaUtil.toDate(bal.getDt().getDt()).getTime() + day);
+        final long day = 24 * 60 * 60 * 1000L;
+        if(report.getBal().size()>0){
+            CashBalance3 firstBal = report.getBal().get(0);
+            BalanceType12Code firstCode = firstBal.getTp().getCdOrPrtry().getCd();
+            if(firstCode == BalanceType12Code.PRCD || firstCode == BalanceType12Code.ITBD) {
+                tag.start.value = new Value(this.checkDebit(firstBal.getAmt().getValue(),firstBal.getCdtDbtInd()));
+                tag.start.value.setCurr(firstBal.getAmt().getCcy());
+                if(firstCode == BalanceType12Code.PRCD){
+                    //  Wir erhoehen noch das Datum um einen Tag, damit aus dem
+                    // Schlusssaldo des Vortages der Startsaldo des aktuellen Tages wird.
+                    tag.start.timestamp = new Date(SepaUtil.toDate(firstBal.getDt().getDt()).getTime() + day);
+                }else{
+                    // bei einem Zwischensaldo ist der Tag derselbe
+                    tag.start.timestamp = new Date(SepaUtil.toDate(firstBal.getDt().getDt()).getTime());
+                }
             }
-            
-            // End-Saldo
-            else if (code == BalanceType12Code.CLBD)
-            {
-                tag.end.value = new Value(this.checkDebit(bal.getAmt().getValue(),bal.getCdtDbtInd()));
-                tag.end.value.setCurr(bal.getAmt().getCcy());
-                tag.end.timestamp = SepaUtil.toDate(bal.getDt().getDt());
+
+            // Zweiter Balance Eintrag ist ein Schlusssaldo oder auch ein Zwischensaldo
+            if(report.getBal().size()>1){
+                CashBalance3 secondBal = report.getBal().get(1);
+                BalanceType12Code secondCode = secondBal.getTp().getCdOrPrtry().getCd();
+                if(secondCode == BalanceType12Code.CLBD || secondCode == BalanceType12Code.ITBD) {
+                    tag.end.value = new Value(this.checkDebit(secondBal.getAmt().getValue(),secondBal.getCdtDbtInd()));
+                    tag.end.value.setCurr(secondBal.getAmt().getCcy());
+                    tag.end.timestamp = SepaUtil.toDate(secondBal.getDt().getDt());
+                }
             }
         }
         //

--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200106.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200106.java
@@ -25,6 +25,7 @@ import java.io.InputStream;
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.List;
+import java.util.Optional;
 
 import javax.xml.bind.JAXB;
 
@@ -32,10 +33,11 @@ import org.kapott.hbci.GV.SepaUtil;
 import org.kapott.hbci.GV_Result.GVRKUms.BTag;
 import org.kapott.hbci.GV_Result.GVRKUms.UmsLine;
 import org.kapott.hbci.manager.HBCIUtils;
+import org.kapott.hbci.sepa.jaxb.camt_052_001_06.BalanceType12Code;
+
 import org.kapott.hbci.sepa.jaxb.camt_052_001_06.AccountIdentification4Choice;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_06.AccountReport19;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_06.ActiveOrHistoricCurrencyAndAmount;
-import org.kapott.hbci.sepa.jaxb.camt_052_001_06.BalanceType12Code;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_06.BankToCustomerAccountReportV06;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_06.BankTransactionCodeStructure4;
 import org.kapott.hbci.sepa.jaxb.camt_052_001_06.BranchAndFinancialInstitutionIdentification5;
@@ -124,7 +126,7 @@ public class ParseCamt05200106 extends AbstractCamtParser
     /**
      * Erzeugt eine einzelne Umsatzbuchung.
      * @param entry der Entry aus der CAMT-Datei.
-     * @param der aktuelle Saldo vor dieser Buchung.
+     * @param currSaldo der aktuelle Saldo vor dieser Buchung.
      * @return die Umsatzbuchung.
      */
     private UmsLine createLine(ReportEntry8 entry, BigDecimal currSaldo)
@@ -158,6 +160,10 @@ public class ParseCamt05200106 extends AbstractCamtParser
         if (ref != null)
         {
             line.id = trim(ref.getPrtry() != null && ref.getPrtry().size() > 0 ? ref.getPrtry().get(0).getRef() : null);
+            // einige Banken verwenden das Account Servicer Reference als eindeutigen Identifier
+            if(line.id==null) {
+                line.id = Optional.ofNullable(entry.getAcctSvcrRef()).orElse(ref.getAcctSvcrRef());
+            }
             line.endToEndId = trim(ref.getEndToEndId());
             line.mandateId = trim(ref.getMndtId());
         }
@@ -295,28 +301,32 @@ public class ParseCamt05200106 extends AbstractCamtParser
 
         ////////////////////////////////////////////////////////////////
         // Start- un End-Saldo ermitteln
-        final long day = 24 * 60 * 60 * 1000L; 
-        for (CashBalance7 bal:report.getBal())
-        {
-            BalanceType12Code code = bal.getTp().getCdOrPrtry().getCd();
-            
-            // Schluss-Saldo vom Vortag
-            if (code == BalanceType12Code.PRCD)
-            {
-                tag.start.value = new Value(this.checkDebit(bal.getAmt().getValue(),bal.getCdtDbtInd()));
-                tag.start.value.setCurr(bal.getAmt().getCcy());
-                
-                //  Wir erhoehen noch das Datum um einen Tag, damit aus dem
-                // Schlusssaldo des Vortages der Startsaldo des aktuellen Tages wird.
-                tag.start.timestamp = new Date(SepaUtil.toDate(bal.getDt().getDt()).getTime() + day);
+        final long day = 24 * 60 * 60 * 1000L;
+        if(report.getBal().size()>0){
+            CashBalance7 firstBal = report.getBal().get(0);
+            org.kapott.hbci.sepa.jaxb.camt_052_001_06.BalanceType12Code firstCode = firstBal.getTp().getCdOrPrtry().getCd();
+            if(firstCode == BalanceType12Code.PRCD || firstCode == BalanceType12Code.ITBD) {
+                tag.start.value = new Value(this.checkDebit(firstBal.getAmt().getValue(),firstBal.getCdtDbtInd()));
+                tag.start.value.setCurr(firstBal.getAmt().getCcy());
+                if(firstCode == BalanceType12Code.PRCD){
+                    //  Wir erhoehen noch das Datum um einen Tag, damit aus dem
+                    // Schlusssaldo des Vortages der Startsaldo des aktuellen Tages wird.
+                    tag.start.timestamp = new Date(SepaUtil.toDate(firstBal.getDt().getDt()).getTime() + day);
+                }else{
+                    // bei einem Zwischensaldo ist der Tag derselbe
+                    tag.start.timestamp = new Date(SepaUtil.toDate(firstBal.getDt().getDt()).getTime());
+                }
             }
-            
-            // End-Saldo
-            else if (code == BalanceType12Code.CLBD)
-            {
-                tag.end.value = new Value(this.checkDebit(bal.getAmt().getValue(),bal.getCdtDbtInd()));
-                tag.end.value.setCurr(bal.getAmt().getCcy());
-                tag.end.timestamp = SepaUtil.toDate(bal.getDt().getDt());
+
+            // Zweiter Balance Eintrag ist ein Schlusssaldo oder auch ein Zwischensaldo
+            if(report.getBal().size()>1){
+                CashBalance7 secondBal = report.getBal().get(1);
+                BalanceType12Code secondCode = secondBal.getTp().getCdOrPrtry().getCd();
+                if(secondCode == BalanceType12Code.CLBD || secondCode == BalanceType12Code.ITBD) {
+                    tag.end.value = new Value(this.checkDebit(secondBal.getAmt().getValue(),secondBal.getCdtDbtInd()));
+                    tag.end.value.setCurr(secondBal.getAmt().getCcy());
+                    tag.end.timestamp = SepaUtil.toDate(secondBal.getDt().getDt());
+                }
             }
         }
         //


### PR DESCRIPTION
Bei mehreren Camt-Nachrichten für einen Buchungsdaten werden nun Zwischensalden (ITBD) berücksichtigt, damit die laufende Saldo pro Buchung stimmt.

Die eindeutige Buchungsreferenz kann alternativ auch der "Account Servicer Reference" sein. 

JavaDoc korrigiert.

Fixes #42 