### PR TITLE
Fix für fillJobResult im Falle von Wrapping durch TAN GV

### DIFF
--- a/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
+++ b/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
@@ -219,7 +219,7 @@ public class GVTAN2Step extends HBCIJobImpl
             // Muessen wir extra pruefen, weil das hier auch das HITAN sein koennte. Das schauen wir aber nicht an
             if (StringUtil.toInsCode(this.task.getHBCICode()).equals(segCode))
             {
-                HBCIUtils.log("this is a response segment for the original task - storing results in the original job",HBCIUtils.LOG_DEBUG);
+                HBCIUtils.log("this is a response segment for the original task (" + this.task.getName() + ") - storing results in the original job",HBCIUtils.LOG_DEBUG);
                 this.task.extractResults(msgstatus,header,idx);
             }
             

--- a/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
+++ b/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
@@ -220,7 +220,7 @@ public class GVTAN2Step extends HBCIJobImpl
             if (StringUtil.toInsCode(this.task.getHBCICode()).equals(segCode))
             {
                 HBCIUtils.log("this is a response segment for the original task (" + this.task.getName() + ") - storing results in the original job",HBCIUtils.LOG_DEBUG);
-                this.task.extractResults(msgstatus,header,idx);
+                this.task.fillJobResultFromTanJob(msgstatus, header, idx);
             }
             
             // Wir haben hier nichts weiter zu tun

--- a/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
+++ b/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
@@ -857,8 +857,22 @@ public abstract class HBCIJobImpl
         return null;
     }
 
+    /* füllt das Objekt mit den Rückgabedaten, wenn der GV durch einen TAN Task
+    gewrapped wurde und die GV-spezifischen Daten daraus übernommen werden müssen.
+    Siehe dazu auch HBCIJobImpl::fillJobResult() 
+    */
+    public void fillJobResultFromTanJob(HBCIMsgStatus status,String header,int seg)
+    {
+        Properties result = status.getData();
+        saveBasicValues(result, seg);
+        saveReturnValues(status, seg);
 
-
+        // wichtig um Parameter wie "content" zu füllen
+        extractPlaintextResults(status, header, contentCounter);
+        // der contentCounter wird fuer jedes antwortsegment um 1 erhoeht
+        extractResults(status, header, contentCounter++);
+    }
+    
     /* füllt das Objekt mit den Rückgabedaten. Dazu wird zuerst eine Liste aller
        Segmente erstellt, die Rückgabedaten für diesen Task enthalten. Anschließend
        werden die HBCI-Rückgabewerte (RetSegs) im outStore gespeichert. Danach werden

--- a/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
@@ -223,10 +223,14 @@ public final class HBCIDialog
                 int taskNum = 0;
                 for (HBCIJobImpl task:tasks)
                 {
-                    if (task.skipped())
-                        continue;
-                    
                     final String name = task.getName();
+
+                    if (task.skipped())
+                    {
+                        HBCIUtils.log("skipping task " + name, HBCIUtils.LOG_DEBUG);
+                        continue;
+                    }
+                    
                     HBCIUtils.log("adding task " + name,HBCIUtils.LOG_DEBUG);
                     HBCIUtilsInternal.getCallback().status(p,HBCICallback.STATUS_SEND_TASK,task);
 
@@ -276,11 +280,17 @@ public final class HBCIDialog
                     // für jeden Task die entsprechenden Rückgabedaten-Klassen füllen
                     for (HBCIJobImpl task:tasks)
                     {
+                        final String name = task.getName();
+
                         if (task.skipped())
+                        {
+                            HBCIUtils.log("skipping results for task " + name, HBCIUtils.LOG_DEBUG);
                             continue;
-                        
+                        }
+
                         try
                         {
+                            HBCIUtils.log("filling results for task " + name, HBCIUtils.LOG_DEBUG);
                             task.fillJobResult(msgstatus,segnum);
                             HBCIUtilsInternal.getCallback().status(p,HBCICallback.STATUS_SEND_TASK_DONE,task);
                         }
@@ -308,8 +318,13 @@ public final class HBCIDialog
                 HBCIMessage newMsg = null;
                 for (HBCIJobImpl task:tasks)
                 {
+                    final String name = task.getName();
+
                     if (task.skipped())
+                    {
+                        HBCIUtils.log("skipping repeat for task " + name, HBCIUtils.LOG_DEBUG);
                         continue;
+                    }
                     
                     HBCIJobImpl redo = task.redo();
                     if (redo != null)

--- a/src/main/java/org/kapott/hbci/tools/HBCIBatch.java
+++ b/src/main/java/org/kapott/hbci/tools/HBCIBatch.java
@@ -213,6 +213,8 @@ public class HBCIBatch {
                                 tan = brTest.readLine();
                                 if (!tan.isEmpty()) {
                                     retData.replace(0, retData.length(), tan);
+                                    //lösche die verwendete TAN, da Folge GVs ggf. neue TANs erfordern
+                                    new FileWriter(tanFile, false).close();
                                     break;
                                 }
                                 brTest.close();

--- a/src/main/java/org/kapott/hbci/tools/HBCIBatch.java
+++ b/src/main/java/org/kapott/hbci/tools/HBCIBatch.java
@@ -206,7 +206,7 @@ public class HBCIBatch {
                     int rounds = 0;
                     File tanFile = new File(value);
                     String tan = null;
-                    while (rounds < 60) {
+                    while (rounds < 120) {
                         if (tanFile.exists()) {
                             try {
                                 BufferedReader brTest = new BufferedReader(new FileReader(tanFile));


### PR DESCRIPTION
Wenn ein GV eine TAN erfordert wird dieser gewrapped durch einen GV TAN (2Step).
In diesem Fall wird das Result im TAN GV verarbeitet und an die Helfermethoden des eigentlichen GV weitergeleitet. Die bisherige Implementierung hatte dabei nur die geparsten Informationen im Sinn. Der Aufruf von HBCIJobImpl::extractResults füllt nur die High-Level Ebene. Alle Parameter (zB. "content") zur Weiterverarbeitung zb. via HBCIBatch gehen verloren. Das führte zu leeren Ergebnissen oder dem Fehlen der ersten Seite. Im Patch wird eine neue Helfermethode geschaffen, die die internen Parameter setzt und vor allem auch den contentCounter erhöht.

Außerdem wurden die Debugging Informationen erweitert und die Zeit zur Bereitstellung einer TAN via File im HBCIBatch erhöht.