### PR TITLE
issue-49: indexed parameters für SEPA Drittstaat Lastschriften

### DIFF
--- a/src/main/java/org/kapott/hbci/GV/generators/GenLastSEPA00800101.java
+++ b/src/main/java/org/kapott/hbci/GV/generators/GenLastSEPA00800101.java
@@ -186,15 +186,15 @@ public class GenLastSEPA00800101 extends AbstractSEPAGenerator<Properties>
         drctDbtTxInf.getDbtrAgt().getFinInstnId().setBIC(sepaParams.getProperty(SepaUtil.insertIndex("dst.bic", index)));
 
         //Payment Information - notwendig bei Sepa Lastschriften in Drittstaaten (CH, UK?)
-        String property = sepaParams.getProperty("dst.addr.country");
+        String property = sepaParams.getProperty(SepaUtil.insertIndex("dst.addr.country", index));
         if (property != null && property.length() > 0) {
             drctDbtTxInf.getDbtr().setPstlAdr(new PostalAddress5());
             // Country Code, zb DE, CH etc. [A-Z]{2,2}
-            drctDbtTxInf.getDbtr().getPstlAdr().setCtry(sepaParams.getProperty("dst.addr.country"));
+            drctDbtTxInf.getDbtr().getPstlAdr().setCtry(sepaParams.getProperty(SepaUtil.insertIndex("dst.addr.country", index)));
             // max 2 Zeilen mit Text min 1, max 70 Zeichen
-            for (int i = 0; i < 2; i++) {
-                String addressLine = sepaParams.getProperty("dst.addr.line" + i);
-                if (addressLine.length() > 0) {
+            for (int i = 1; i <= 2; i++) {
+                String addressLine = sepaParams.getProperty(SepaUtil.insertIndex("dst.addr.line" + i, index));
+                if (addressLine != null && addressLine.length() > 0) {
                     drctDbtTxInf.getDbtr().getPstlAdr().getAdrLine().add(addressLine);
                 }
             }

--- a/src/main/java/org/kapott/hbci/GV/generators/GenLastSEPA00800102.java
+++ b/src/main/java/org/kapott/hbci/GV/generators/GenLastSEPA00800102.java
@@ -220,17 +220,17 @@ public class GenLastSEPA00800102 extends AbstractSEPAGenerator<Properties>
     }
 
     // Payment Information - notwendig bei Sepa Lastschriften in Drittstaaten (CH, UK?)
-    String property = sepaParams.getProperty("dst.addr.country");
+    String property = sepaParams.getProperty(SepaUtil.insertIndex("dst.addr.country", index));
     if (property != null && property.length() > 0)
     {
       drctDbtTxInf.getDbtr().setPstlAdr(new PostalAddressSEPA());
       // Country Code, zb DE, CH etc. [A-Z]{2,2}
-      drctDbtTxInf.getDbtr().getPstlAdr().setCtry(sepaParams.getProperty("dst.addr.country"));
+      drctDbtTxInf.getDbtr().getPstlAdr().setCtry(sepaParams.getProperty(SepaUtil.insertIndex("dst.addr.country", index)));
       // max 2 Zeilen mit Text min 1, max 70 Zeichen
-      for (int i = 0; i < 2; i++)
+      for (int i = 1; i <= 2; i++)
       {
-        String addressLine = sepaParams.getProperty("dst.addr.line" + i);
-        if (addressLine.length() > 0)
+        String addressLine = sepaParams.getProperty(SepaUtil.insertIndex("dst.addr.line" + i, index));
+        if (addressLine != null && addressLine.length() > 0)
         {
           drctDbtTxInf.getDbtr().getPstlAdr().getAdrLine().add(addressLine);
         }

--- a/src/main/java/org/kapott/hbci/GV/generators/GenLastSEPA00800201.java
+++ b/src/main/java/org/kapott/hbci/GV/generators/GenLastSEPA00800201.java
@@ -81,7 +81,7 @@ public class GenLastSEPA00800201 extends AbstractSEPAGenerator<Properties>
         //Customer Credit Transfer Initiation
         doc.setPain00800101(new Pain00800101());
         doc.getPain00800101().setGrpHdr(new GroupHeaderSDD());
-        
+
         String batch = SepaUtil.getProperty(sepaParams,"batchbook",null);
         if (batch != null)
             doc.getPain00800101().getGrpHdr().setBtchBookg(batch.equals("1"));
@@ -132,7 +132,7 @@ public class GenLastSEPA00800201 extends AbstractSEPAGenerator<Properties>
         pmtInf.getPmtTpInf().setSvcLvl(new ServiceLevelSDD());
         pmtInf.getPmtTpInf().getSvcLvl().setCd(ServiceLevelSDDCode.SEPA);
         pmtInf.getPmtTpInf().setLclInstrm(new LocalInstrumentSDD());
-        
+
         String type = sepaParams.getProperty("type");
         try
         {
@@ -142,7 +142,7 @@ public class GenLastSEPA00800201 extends AbstractSEPAGenerator<Properties>
         {
             throw new HBCI_Exception("Lastschrift-Art " + type + " wird in der SEPA-Version 008.002.01 Ihrer Bank noch nicht unterstützt",e);
         }
-        
+
         //Payment Information - Credit Transfer Transaction Information
         ArrayList<DirectDebitTransactionInformationSDD> drctDbtTxInfs = (ArrayList<DirectDebitTransactionInformationSDD>) pmtInf.getDrctDbtTxInf();
         if (maxIndex != null)
@@ -212,15 +212,15 @@ public class GenLastSEPA00800201 extends AbstractSEPAGenerator<Properties>
         drctDbtTxInf.getDbtrAgt().getFinInstnId().setBIC(sepaParams.getProperty(SepaUtil.insertIndex("dst.bic", index)));
 
         //Payment Information - notwendig bei Sepa Lastschriften in Drittstaaten (CH, UK?)
-        String property = sepaParams.getProperty("dst.addr.country");
+        String property = sepaParams.getProperty(SepaUtil.insertIndex("dst.addr.country", index));
         if (property != null && property.length() > 0) {
             drctDbtTxInf.getDbtr().setPstlAdr(new PostalAddressSDD());
             // Country Code, zb DE, CH etc. [A-Z]{2,2}
-            drctDbtTxInf.getDbtr().getPstlAdr().setCtry(sepaParams.getProperty("dst.addr.country"));
+            drctDbtTxInf.getDbtr().getPstlAdr().setCtry(sepaParams.getProperty(SepaUtil.insertIndex("dst.addr.country", index)));
             // max 2 Zeilen mit Text min 1, max 70 Zeichen
-            for (int i = 0; i < 2; i++) {
-                String addressLine = sepaParams.getProperty("dst.addr.line" + i);
-                if (addressLine.length() > 0) {
+            for (int i = 1; i <= 2; i++) {
+                String addressLine = sepaParams.getProperty(SepaUtil.insertIndex("dst.addr.line" + i, index));
+                if (addressLine != null && addressLine.length() > 0) {
                     drctDbtTxInf.getDbtr().getPstlAdr().getAdrLine().add(addressLine);
                 }
             }
@@ -239,7 +239,7 @@ public class GenLastSEPA00800201 extends AbstractSEPAGenerator<Properties>
             drctDbtTxInf.setRmtInf(new RemittanceInformationSDDChoice());
             drctDbtTxInf.getRmtInf().setUstrd(usage);
         }
-        
+
         String purposeCode = sepaParams.getProperty(SepaUtil.insertIndex("purposecode", index));
         if (purposeCode != null && purposeCode.length() > 0)
         {
@@ -247,7 +247,7 @@ public class GenLastSEPA00800201 extends AbstractSEPAGenerator<Properties>
             p.setCd(purposeCode);
             drctDbtTxInf.setPurp(p);
         }
-        
+
 
         return drctDbtTxInf;
     }

--- a/src/main/java/org/kapott/hbci/GV/generators/GenLastSEPA00800202.java
+++ b/src/main/java/org/kapott/hbci/GV/generators/GenLastSEPA00800202.java
@@ -130,7 +130,7 @@ public class GenLastSEPA00800202 extends AbstractSEPAGenerator<Properties>
         pmtInf.getPmtTpInf().setSvcLvl(new ServiceLevelSEPA());
         pmtInf.getPmtTpInf().getSvcLvl().setCd(ServiceLevelSEPACode.SEPA);
         pmtInf.getPmtTpInf().setLclInstrm(new LocalInstrumentSEPA());
-        
+
         String type = sepaParams.getProperty("type");
         try
         {
@@ -212,15 +212,15 @@ public class GenLastSEPA00800202 extends AbstractSEPAGenerator<Properties>
         drctDbtTxInf.getDbtrAgt().getFinInstnId().setBIC(sepaParams.getProperty(SepaUtil.insertIndex("dst.bic", index)));
 
         //Payment Information - notwendig bei Sepa Lastschriften in Drittstaaten (CH, UK?)
-        String property = sepaParams.getProperty("dst.addr.country");
+        String property = sepaParams.getProperty(SepaUtil.insertIndex("dst.addr.country", index));
         if (property != null && property.length() > 0) {
             drctDbtTxInf.getDbtr().setPstlAdr(new PostalAddressSEPA());
             // Country Code, zb DE, CH etc. [A-Z]{2,2}
-            drctDbtTxInf.getDbtr().getPstlAdr().setCtry(sepaParams.getProperty("dst.addr.country"));
+            drctDbtTxInf.getDbtr().getPstlAdr().setCtry(sepaParams.getProperty(SepaUtil.insertIndex("dst.addr.country", index)));
             // max 2 Zeilen mit Text min 1, max 70 Zeichen
-            for (int i = 0; i < 2; i++) {
-                String addressLine = sepaParams.getProperty("dst.addr.line" + i);
-                if (addressLine.length() > 0) {
+            for (int i = 1; i <= 2; i++) {
+                String addressLine = sepaParams.getProperty(SepaUtil.insertIndex("dst.addr.line" + i, index));
+                if (addressLine != null && addressLine.length() > 0) {
                     drctDbtTxInf.getDbtr().getPstlAdr().getAdrLine().add(addressLine);
                 }
             }

--- a/src/main/java/org/kapott/hbci/GV/generators/GenLastSEPA00800302.java
+++ b/src/main/java/org/kapott/hbci/GV/generators/GenLastSEPA00800302.java
@@ -222,15 +222,15 @@ public class GenLastSEPA00800302 extends AbstractSEPAGenerator<Properties>
         }
 
         //Payment Information - notwendig bei Sepa Lastschriften in Drittstaaten (CH, UK?)
-        String property = sepaParams.getProperty("dst.addr.country");
+        String property = sepaParams.getProperty(SepaUtil.insertIndex("dst.addr.country", index));
         if (property != null && property.length() > 0) {
             drctDbtTxInf.getDbtr().setPstlAdr(new PostalAddressSEPA());
             // Country Code, zb DE, CH etc. [A-Z]{2,2}
-            drctDbtTxInf.getDbtr().getPstlAdr().setCtry(sepaParams.getProperty("dst.addr.country"));
+            drctDbtTxInf.getDbtr().getPstlAdr().setCtry(sepaParams.getProperty(SepaUtil.insertIndex("dst.addr.country", index)));
             // max 2 Zeilen mit Text min 1, max 70 Zeichen
-            for (int i = 0; i < 2; i++) {
-                String addressLine = sepaParams.getProperty("dst.addr.line" + i);
-                if (addressLine.length() > 0) {
+            for (int i = 1; i <= 2; i++) {
+                String addressLine = sepaParams.getProperty(SepaUtil.insertIndex("dst.addr.line" + i, index));
+                if (addressLine != null && addressLine.length() > 0) {
                     drctDbtTxInf.getDbtr().getPstlAdr().getAdrLine().add(addressLine);
                 }
             }


### PR DESCRIPTION
Fix, um auch Sammellastschriften zu bedienen.
Und Index für Adresszeilen startet mit 1

Die Parameter lauten

dst.addr.country
dst.addr.line1
dst.addr.line2

und können pro Lastschrift angegeben werden.
