### PR TITLE
Refactoring: int -> enum in `HBCICallback`

### DIFF
--- a/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
+++ b/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
@@ -36,6 +36,7 @@ import java.util.regex.Pattern;
 import org.kapott.hbci.GV_Result.HBCIJobResult;
 import org.kapott.hbci.GV_Result.HBCIJobResultImpl;
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.dialog.KnownReturncode;
 import org.kapott.hbci.exceptions.HBCI_Exception;
 import org.kapott.hbci.exceptions.InvalidArgumentException;
@@ -1050,7 +1051,7 @@ public abstract class HBCIJobImpl
                 HBCIUtilsInternal.getCallback().callback(getMainPassport(),
                                                  HBCICallback.HAVE_CRC_ERROR,
                                                  HBCIUtilsInternal.getLocMsg("CALLB_HAVE_CRC_ERROR"),
-                                                 HBCICallback.ResponseType.TEXT,
+                                                 ResponseType.TEXT,
                                                  sb);
 
                 int idx=sb.indexOf("|");
@@ -1093,7 +1094,7 @@ public abstract class HBCIJobImpl
     			HBCIUtilsInternal.getCallback().callback(getMainPassport(),
     					HBCICallback.HAVE_IBAN_ERROR,
     					HBCIUtilsInternal.getLocMsg("CALLB_HAVE_IBAN_ERROR"),
-    					HBCICallback.ResponseType.TEXT,
+    					ResponseType.TEXT,
     					sb);
 
     			iban=sb.toString();

--- a/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
+++ b/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
@@ -35,7 +35,7 @@ import java.util.regex.Pattern;
 
 import org.kapott.hbci.GV_Result.HBCIJobResult;
 import org.kapott.hbci.GV_Result.HBCIJobResultImpl;
-import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.dialog.KnownReturncode;
 import org.kapott.hbci.exceptions.HBCI_Exception;
@@ -1049,7 +1049,7 @@ public abstract class HBCIJobImpl
             	// wenn beim validieren ein fehler auftrat, nach neuen daten fragen
                 StringBuffer sb=new StringBuffer(blz).append("|").append(number);
                 HBCIUtilsInternal.getCallback().callback(getMainPassport(),
-                                                 HBCICallback.Reason.HAVE_CRC_ERROR,
+                                                 Reason.HAVE_CRC_ERROR,
                                                  HBCIUtilsInternal.getLocMsg("CALLB_HAVE_CRC_ERROR"),
                                                  ResponseType.TEXT,
                                                  sb);
@@ -1092,7 +1092,7 @@ public abstract class HBCIJobImpl
     		if (!crcok) {
     			StringBuffer sb=new StringBuffer(iban);
     			HBCIUtilsInternal.getCallback().callback(getMainPassport(),
-    					HBCICallback.Reason.HAVE_IBAN_ERROR,
+    					Reason.HAVE_IBAN_ERROR,
     					HBCIUtilsInternal.getLocMsg("CALLB_HAVE_IBAN_ERROR"),
     					ResponseType.TEXT,
     					sb);

--- a/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
+++ b/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
@@ -1049,7 +1049,7 @@ public abstract class HBCIJobImpl
             	// wenn beim validieren ein fehler auftrat, nach neuen daten fragen
                 StringBuffer sb=new StringBuffer(blz).append("|").append(number);
                 HBCIUtilsInternal.getCallback().callback(getMainPassport(),
-                                                 HBCICallback.HAVE_CRC_ERROR,
+                                                 HBCICallback.Reason.HAVE_CRC_ERROR,
                                                  HBCIUtilsInternal.getLocMsg("CALLB_HAVE_CRC_ERROR"),
                                                  ResponseType.TEXT,
                                                  sb);
@@ -1092,7 +1092,7 @@ public abstract class HBCIJobImpl
     		if (!crcok) {
     			StringBuffer sb=new StringBuffer(iban);
     			HBCIUtilsInternal.getCallback().callback(getMainPassport(),
-    					HBCICallback.HAVE_IBAN_ERROR,
+    					HBCICallback.Reason.HAVE_IBAN_ERROR,
     					HBCIUtilsInternal.getLocMsg("CALLB_HAVE_IBAN_ERROR"),
     					ResponseType.TEXT,
     					sb);

--- a/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
+++ b/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
@@ -1050,7 +1050,7 @@ public abstract class HBCIJobImpl
                 HBCIUtilsInternal.getCallback().callback(getMainPassport(),
                                                  HBCICallback.HAVE_CRC_ERROR,
                                                  HBCIUtilsInternal.getLocMsg("CALLB_HAVE_CRC_ERROR"),
-                                                 HBCICallback.ResponseType.TYPE_TEXT,
+                                                 HBCICallback.ResponseType.TEXT,
                                                  sb);
 
                 int idx=sb.indexOf("|");
@@ -1093,7 +1093,7 @@ public abstract class HBCIJobImpl
     			HBCIUtilsInternal.getCallback().callback(getMainPassport(),
     					HBCICallback.HAVE_IBAN_ERROR,
     					HBCIUtilsInternal.getLocMsg("CALLB_HAVE_IBAN_ERROR"),
-    					HBCICallback.ResponseType.TYPE_TEXT,
+    					HBCICallback.ResponseType.TEXT,
     					sb);
 
     			iban=sb.toString();

--- a/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
+++ b/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
@@ -1050,7 +1050,7 @@ public abstract class HBCIJobImpl
                 HBCIUtilsInternal.getCallback().callback(getMainPassport(),
                                                  HBCICallback.HAVE_CRC_ERROR,
                                                  HBCIUtilsInternal.getLocMsg("CALLB_HAVE_CRC_ERROR"),
-                                                 HBCICallback.TYPE_TEXT,
+                                                 HBCICallback.ResponseType.TYPE_TEXT,
                                                  sb);
 
                 int idx=sb.indexOf("|");
@@ -1093,7 +1093,7 @@ public abstract class HBCIJobImpl
     			HBCIUtilsInternal.getCallback().callback(getMainPassport(),
     					HBCICallback.HAVE_IBAN_ERROR,
     					HBCIUtilsInternal.getLocMsg("CALLB_HAVE_IBAN_ERROR"),
-    					HBCICallback.TYPE_TEXT,
+    					HBCICallback.ResponseType.TYPE_TEXT,
     					sb);
 
     			iban=sb.toString();

--- a/src/main/java/org/kapott/hbci/callback/AbstractHBCICallback.java
+++ b/src/main/java/org/kapott/hbci/callback/AbstractHBCICallback.java
@@ -87,7 +87,7 @@ public abstract class AbstractHBCICallback
     
     /** Standard-Verhalten - gibt für alle Callbacks <code>false</code> (= asynchrone
      * Callback-Behandlung) zurück.*/
-    public boolean useThreadedCallback(HBCIPassport passport, int reason, String msg,
+    public boolean useThreadedCallback(HBCIPassport passport, Reason reason, String msg,
                                        ResponseType datatype, StringBuffer retData)
     {
         return false;

--- a/src/main/java/org/kapott/hbci/callback/AbstractHBCICallback.java
+++ b/src/main/java/org/kapott/hbci/callback/AbstractHBCICallback.java
@@ -87,8 +87,8 @@ public abstract class AbstractHBCICallback
     
     /** Standard-Verhalten - gibt für alle Callbacks <code>false</code> (= asynchrone
      * Callback-Behandlung) zurück.*/
-    public boolean useThreadedCallback(HBCIPassport passport,int reason,String msg,
-                                       int datatype,StringBuffer retData)
+    public boolean useThreadedCallback(HBCIPassport passport, int reason, String msg,
+                                       ResponseType datatype, StringBuffer retData)
     {
         return false;
     }

--- a/src/main/java/org/kapott/hbci/callback/AbstractHBCICallback.java
+++ b/src/main/java/org/kapott/hbci/callback/AbstractHBCICallback.java
@@ -80,7 +80,7 @@ public abstract class AbstractHBCICallback
         return ret.toString();
     }
 
-    public synchronized final void status(HBCIPassport passport,int statusTag,Object o)
+    public synchronized final void status(HBCIPassport passport,Status statusTag,Object o)
     {
         status(passport,statusTag,new Object[] {o});
     }

--- a/src/main/java/org/kapott/hbci/callback/HBCICallback.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallback.java
@@ -109,11 +109,11 @@ public interface HBCICallback
         <p>Beim Auftreten dieses Callbacks muss die Anwendung also die gerade empfangenen Schlüsseldaten der
         Bank (öffentlicher Signier-/Chiffrierschlüssel) geeignet anzeigen (Exponent, Modulus, Hash-Wert) und
         den Anwender auffordern, diese Daten mit denen aus dem INI-Brief zu vergleichen. Dieser Callback
-        erwartet als Rückgabedaten einen Boolean-Wert (siehe {@link #TYPE_BOOLEAN}). Sind die Daten
+        erwartet als Rückgabedaten einen Boolean-Wert (siehe {@link ResponseType#TYPE_BOOLEAN}). Sind die Daten
         in Ordnung, so muss die Callback-Methode einen leeren String in dem Rückgabedaten-StringBuffer
         zurückgeben, ansonsten füllt sie den StringBuffer mit einem beliebigen nichtleeren String (siehe dazu
-        {@link #callback(org.kapott.hbci.passport.HBCIPassport,int,String,int,StringBuffer)} und
-        die Beschreibung des Rückgabe-Datentyps {@link #TYPE_BOOLEAN})).</p>
+        {@link #callback(org.kapott.hbci.passport.HBCIPassport,int,String, ResponseType,StringBuffer)} und
+        die Beschreibung des Rückgabe-Datentyps {@link ResponseType#TYPE_BOOLEAN})).</p>
         <p>Da im Moment keine dokumentierten Methoden zur Verfügung stehen, um aus einem Passport die
         entsprechenden Schlüsseldaten zum Anzeigen zu extrahieren, wird folgendes Vorgehen empfohlen:
         die Anwendung erzeugt eine HBCICallback-Klasse, die von einer der bereits vorhandenen 
@@ -144,7 +144,7 @@ public interface HBCICallback
     public final static int HAVE_NEW_MY_KEYS=13;
     /** Ursache des Callback-Aufrufes: Institutsnachricht erhalten. Tritt dieser Callback auf, so enthält
         der <code>msg</code>-Parameter der <code>callback</code>-Methode (siehe
-        {@link #callback(org.kapott.hbci.passport.HBCIPassport,int,String,int,StringBuffer)} einen
+        {@link #callback(org.kapott.hbci.passport.HBCIPassport,int,String,ResponseType,StringBuffer)} einen
         String, den die Bank als Kreditinstitutsnachricht an den Kunden gesandt hat. Diese Nachricht sollte
         dem Anwender i.d.R. angezeigt werden. <em>HBCI4Java</em> erwartet auf diesen Callback keine Antwortdaten. */
     public final static int HAVE_INST_MSG=14;
@@ -200,7 +200,7 @@ public interface HBCICallback
         im <code>retData</code> Rückgabedaten-Objekt ein leerer String zurückgegeben wird, oder er kann
         erzwingen, dass <em>HBCI4Java</em> tatsächlich abbricht, indem ein nicht-leerer String im
         <code>retData</code>-Objekt zurückgegen wird. Siehe dazu auch die Beschreibung des
-        Rückgabe-Datentyps {@link #TYPE_BOOLEAN}.</p>
+        Rückgabe-Datentyps {@link ResponseType#TYPE_BOOLEAN}.</p>
         <p>Das Ignorieren eines Fehlers kann dazu führen, dass <em>HBCI4Java</em> später trotzdem eine
         Exception erzeugt, z.B. weil der Fehler in einem bestimmten Submodul doch nicht einfach ignoriert
         werden kann, oder es kann auch dazu führen, dass Aufträge von der Bank nicht angenommen werden usw.
@@ -358,27 +358,28 @@ public interface HBCICallback
     /** <p>im Parameter retData stehen die neuen Daten im Format UserID|CustomerID drin */
     public final static int USERID_CHANGED=41;
 
-    /** erwarteter Datentyp der Antwort: keiner (keine Antwortdaten erwartet) */
-    public final static int TYPE_NONE=0;
-    /** erwarteter Datentyp der Antwort: geheimer Text (bei Eingabe nicht anzeigen) */
-    public final static int TYPE_SECRET=1;
-    /** erwarteter Datentyp der Antwort: "normaler" Text */
-    public final static int TYPE_TEXT=2;
-    /** <p>erwarteter Datentyp der Antwort: ja/nein, true/false, weiter/abbrechen
-        oder ähnlich. Da das 
-        Rückgabedatenobjekt immer ein <code>StringBuffer</code> ist, wird hier
-        folgende Kodierung verwendet: die beiden möglichen Werte für die
-        Antwort (true/false, ja/nein, weiter/abbrechen, usw.) werden dadurch
-        unterschieden, dass für den einen Wert ein <em>leerer</em> String 
-        zurückgegeben wird, für den anderen Wert ein <em>nicht leerer</em>
-        beliebiger String. Einige Callback-Reasons können auch den Inhalt
-        des nicht-leeren Strings auswerten. Eine genaue Beschreibung der jeweilis
-        möglichen Rückgabedaten befinden sich in der Beschreibung der 
-        Callback-Reasons (<code>HAVE_*</code> bzw. <code>NEED_*</code>), bei 
-        denen Boolean-Daten als Rückgabewerte benötigt werden.</p>
-        <p>Siehe dazu auch die Hinweise in der Paketbeschreibung zum Paket
-        <code>org.kapott.hbci.callback</code>.</p> */     
-    public final static int TYPE_BOOLEAN=3;
+    enum ResponseType
+    {
+        /** erwarteter Datentyp der Antwort: keiner (keine Antwortdaten erwartet) */
+        TYPE_NONE,
+        /** erwarteter Datentyp der Antwort: geheimer Text (bei Eingabe nicht anzeigen) */
+        TYPE_SECRET,
+        /** erwarteter Datentyp der Antwort: "normaler" Text */
+        TYPE_TEXT,
+        /**
+         * <p>erwarteter Datentyp der Antwort: ja/nein, true/false, weiter/abbrechen
+         * oder ähnlich. Da das Rückgabedatenobjekt immer ein <code>StringBuffer</code> ist, wird hier folgende Kodierung
+         * verwendet: die beiden möglichen Werte für die Antwort (true/false, ja/nein, weiter/abbrechen, usw.) werden
+         * dadurch unterschieden, dass für den einen Wert ein <em>leerer</em> String zurückgegeben wird, für den anderen
+         * Wert ein <em>nicht leerer</em> beliebiger String. Einige Callback-Reasons können auch den Inhalt des nicht-leeren
+         * Strings auswerten. Eine genaue Beschreibung der jeweilis möglichen Rückgabedaten befinden sich in der
+         * Beschreibung der Callback-Reasons (<code>HAVE_*</code> bzw. <code>NEED_*</code>), bei denen Boolean-Daten als
+         * Rückgabewerte benötigt werden.</p>
+         * <p>Siehe dazu auch die Hinweise in der Paketbeschreibung zum Paket
+         * <code>org.kapott.hbci.callback</code>.</p>
+         */
+        TYPE_BOOLEAN
+    }
     
     /** Kernel-Status: Erzeuge Auftrag zum Versenden. Als Zusatzinformation 
         wird bei diesem Callback das <code>HBCIJob</code>-Objekt des 
@@ -626,13 +627,13 @@ public interface HBCICallback
         abgelegt werden. Beim Aufruf der Callback-Methode von <em>HBCI4Java</em> wird dieser
         StringBuffer u.U. mit einem vorgeschlagenen default-Wert für die Nutzereingabe
         gefüllt. */
-    public void callback(HBCIPassport passport,int reason,String msg,int datatype,StringBuffer retData);
+    public void callback(HBCIPassport passport,int reason,String msg,ResponseType datatype,StringBuffer retData);
     
     /** Wird vom HBCI-Kernel aufgerufen, um einen bestimmten Status der
         Abarbeitung bekanntzugeben.
         @param passport gibt an, welches Passport (und damit welches HBCIHandle)
         benutzt wurde, als der Callback erzeugt wurde (siehe auch
-        {@link #callback(org.kapott.hbci.passport.HBCIPassport,int,String,int,StringBuffer)}).
+        {@link #callback(org.kapott.hbci.passport.HBCIPassport,int,String,ResponseType,StringBuffer)}).
         @param statusTag gibt an, welche Stufe der Abarbeitung gerade erreicht
         wurde (alle oben beschriebenen Konstanten, die mit <code>STATUS_</code>
         beginnen)
@@ -657,12 +658,12 @@ public interface HBCICallback
      * dass sie für alle Callbacks, die synchron behandelt werden sollen,
      * <code>true</code> zurückgibt.</p>
      * <p>Die übergebenen Parameter entsprechen denen der Methode
-     * {@link #callback(HBCIPassport, int, String, int, StringBuffer)}. Der 
+     * {@link #callback(HBCIPassport,int,String,ResponseType,StringBuffer)}. Der
      * Rückgabewert gibt ab, ob dieser Callback synchron (<code>true</code>) oder
      * asynchron (<code>false</code>) behandelt werden soll.</p>
      * <p>Mehr Informationen dazu in der Datei <code>README.ThreadedCallbacks</code>.</p> */
     public boolean useThreadedCallback(HBCIPassport passport,int reason,
-                                       String msg,int datatype,
+                                       String msg,ResponseType datatype,
                                        StringBuffer retData);
 }
 

--- a/src/main/java/org/kapott/hbci/callback/HBCICallback.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallback.java
@@ -40,7 +40,8 @@ import org.kapott.hbci.passport.HBCIPassport;
     Methode dieses Passwort direkt zurückgeben, ohne den Anwender erneut danach zu fragen. </p>*/ 
 public interface HBCICallback
 {
-    enum Reason {
+  enum Reason
+  {
     /** Ursache des Callback-Aufrufes: Chipkarte benötigt (im Chipkartenterminal). Dieser Callback
         tritt auf, wenn der HBCI-Kernel auf das Einlegen der HBCI-Chipkarte in den Chipkartenleser
         wartet. Als Reaktion auf diesen Callback darf nur eine entsprechende Aufforderung o.ä.
@@ -358,30 +359,32 @@ public interface HBCICallback
     /** <p>Ursache des Callbacks: Dialogantwort 3072 der GAD - UserID und CustomerID werden ausgetauscht */
     /** <p>im Parameter retData stehen die neuen Daten im Format UserID|CustomerID drin */
     USERID_CHANGED
-    }
+  }
 
-    enum ResponseType
-    {
-        /** erwarteter Datentyp der Antwort: keiner (keine Antwortdaten erwartet) */
-        NONE,
-        /** erwarteter Datentyp der Antwort: geheimer Text (bei Eingabe nicht anzeigen) */
-        SECRET,
-        /** erwarteter Datentyp der Antwort: "normaler" Text */
-        TEXT,
-        /**
-         * <p>erwarteter Datentyp der Antwort: ja/nein, true/false, weiter/abbrechen
-         * oder ähnlich. Da das Rückgabedatenobjekt immer ein <code>StringBuffer</code> ist, wird hier folgende Kodierung
-         * verwendet: die beiden möglichen Werte für die Antwort (true/false, ja/nein, weiter/abbrechen, usw.) werden
-         * dadurch unterschieden, dass für den einen Wert ein <em>leerer</em> String zurückgegeben wird, für den anderen
-         * Wert ein <em>nicht leerer</em> beliebiger String. Einige Callback-Reasons können auch den Inhalt des nicht-leeren
-         * Strings auswerten. Eine genaue Beschreibung der jeweilis möglichen Rückgabedaten befinden sich in der
-         * Beschreibung der Callback-Reasons (<code>HAVE_*</code> bzw. <code>NEED_*</code>), bei denen Boolean-Daten als
-         * Rückgabewerte benötigt werden.</p>
-         * <p>Siehe dazu auch die Hinweise in der Paketbeschreibung zum Paket
-         * <code>org.kapott.hbci.callback</code>.</p>
-         */
-        BOOLEAN
-    }
+  enum ResponseType
+  {
+    /** erwarteter Datentyp der Antwort: keiner (keine Antwortdaten erwartet) */
+    NONE,
+    /** erwarteter Datentyp der Antwort: geheimer Text (bei Eingabe nicht anzeigen) */
+    SECRET,
+    /** erwarteter Datentyp der Antwort: "normaler" Text */
+    TEXT,
+    /** <p>erwarteter Datentyp der Antwort: ja/nein, true/false, weiter/abbrechen
+        oder ähnlich. Da das
+        Rückgabedatenobjekt immer ein <code>StringBuffer</code> ist, wird hier
+        folgende Kodierung verwendet: die beiden möglichen Werte für die
+        Antwort (true/false, ja/nein, weiter/abbrechen, usw.) werden dadurch
+        unterschieden, dass für den einen Wert ein <em>leerer</em> String
+        zurückgegeben wird, für den anderen Wert ein <em>nicht leerer</em>
+        beliebiger String. Einige Callback-Reasons können auch den Inhalt
+        des nicht-leeren Strings auswerten. Eine genaue Beschreibung der jeweils
+        möglichen Rückgabedaten befinden sich in der Beschreibung der
+        Callback-Reasons (<code>HAVE_*</code> bzw. <code>NEED_*</code>), bei
+        denen Boolean-Daten als Rückgabewerte benötigt werden.</p>
+        <p>Siehe dazu auch die Hinweise in der Paketbeschreibung zum Paket
+        {@link org.kapott.hbci.callback}.</p> */
+    BOOLEAN
+  }
     
     /** Kernel-Status: Erzeuge Auftrag zum Versenden. Als Zusatzinformation 
         wird bei diesem Callback das <code>HBCIJob</code>-Objekt des 

--- a/src/main/java/org/kapott/hbci/callback/HBCICallback.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallback.java
@@ -391,170 +391,170 @@ public interface HBCICallback
     /** Kernel-Status: Erzeuge Auftrag zum Versenden. Als Zusatzinformation
         wird bei diesem Callback das <code>HBCIJob</code>-Objekt des
         Auftrages übergeben, dessen Auftragsdaten gerade erzeugt werden. */
-    STATUS_SEND_TASK,
+    SEND_TASK,
     /** Kernel-Status: Auftrag gesendet. Tritt auf, wenn zu einem bestimmten Job
         Auftragsdaten empfangen und ausgewertet wurden. Als Zusatzinformation wird
         das <code>HBCIJob</code>-Objekt des jeweiligen Auftrages übergeben. */
-    STATUS_SEND_TASK_DONE,
+    SEND_TASK_DONE,
     /** Kernel-Status: hole BPD. Kann nur während der Passport-Initialisierung
         ({@link org.kapott.hbci.manager.HBCIHandler#HBCIHandler(String,org.kapott.hbci.passport.HBCIPassport)})
         auftreten und zeigt an, dass die BPD von der Bank abgeholt werden müssen,
         weil sie noch nicht lokal vorhanden sind. Es werden keine zusätzlichen
         Informationen übergeben. */
-    STATUS_INST_BPD_INIT,
+    INST_BPD_INIT,
     /** Kernel-Status: BPD aktualisiert. Dieser Status-Callback tritt nach dem expliziten
-        Abholen der BPD ({@link #STATUS_INST_BPD_INIT}) auf und kann auch nach einer
+        Abholen der BPD ({@link #INST_BPD_INIT}) auf und kann auch nach einer
         Dialog-Initialisierung auftreten, wenn dabei eine neue BPD vom Kreditinstitut
         empfangen wurde. Als Zusatzinformation wird ein <code>Properties</code>-Objekt
         mit den neuen BPD übergeben. */
-    STATUS_INST_BPD_INIT_DONE,
+    INST_BPD_INIT_DONE,
     /** Kernel-Status: hole Institutsschlüssel. Dieser Status-Callback zeigt an, dass
         <em>HBCI4Java</em> die öffentlichen Schlüssel des Kreditinstitutes abholt.
         Dieser Callback kann nur beim Initialisieren eines Passportes (siehe
         {@link org.kapott.hbci.manager.HBCIHandler#HBCIHandler(String,org.kapott.hbci.passport.HBCIPassport)})
         und bei Verwendung von RDH als Sicherheitsverfahren auftreten. Es werden keine
         zusätzlichen Informationen übergeben. */
-    STATUS_INST_GET_KEYS,
+    INST_GET_KEYS,
     /** Kernel-Status: Institutsschlüssel aktualisiert. Dieser Callback tritt
         auf, wenn <em>HBCI4Java</em> neue öffentliche Schlüssel der Bank
         empfangen hat. Dieser Callback kann nach dem expliziten Anfordern der
-        neuen Schlüssel ({@link #STATUS_INST_GET_KEYS}) oder nach einer Dialog-Initialisierung
+        neuen Schlüssel ({@link #INST_GET_KEYS}) oder nach einer Dialog-Initialisierung
         auftreten, wenn das Kreditinstitut neue Schlüssel übermittelt hat. Es
         werden keine zusätzlichen Informationen übergeben. */
-    STATUS_INST_GET_KEYS_DONE,
+    INST_GET_KEYS_DONE,
     /** Kernel-Status: Sende Nutzerschlüssel. Wird erzeugt, wenn <em>HBCI4Java</em>
         neue Schlüssel des Anwenders an die Bank versendet. Das tritt beim erstmaligen
         Einrichten eines RDH-Passportes bzw. nach dem manuellen Erzeugen neuer
         RDH-Schlüssel auf. Es werden keine zusätzlichen Informationen übergeben. */
-    STATUS_SEND_KEYS,
+    SEND_KEYS,
     /** Kernel-Status: Nutzerschlüssel gesendet. Dieser Callback zeigt an, dass die RDH-Schlüssel
         des Anwenders an die Bank versandt wurden. Der Erfolg dieser Aktion kann nicht
         allein durch das Auftreten dieses Callbacks angenommen werden! Es wird der Status
         des Nachrichtenaustauschs ({@link org.kapott.hbci.status.HBCIMsgStatus})
         als Zusatzinformation übergeben. */
-    STATUS_SEND_KEYS_DONE,
+    SEND_KEYS_DONE,
     /** Kernel-Status: aktualisiere System-ID. Dieser Status-Callback wird erzeugt, wenn
         <em>HBCI4Java</em> die System-ID, die für das RDH-Verfahren benötigt
         wird, synchronisiert. Der Callback kann nur beim Initialisieren eines Passports
         (siehe {@link org.kapott.hbci.manager.HBCIHandler#HBCIHandler(String,org.kapott.hbci.passport.HBCIPassport)})
         auftreten. Es werden keine Zusatzinformationen übergeben. */
-    STATUS_INIT_SYSID,
+    INIT_SYSID,
     /** Kernel-Status: System-ID aktualisiert. Dieser Callback tritt auf, wenn im Zuge der
-        Synchronisierung ({@link #STATUS_INIT_SYSID}) eine System-ID empfangen wurde. Als
+        Synchronisierung ({@link #INIT_SYSID}) eine System-ID empfangen wurde. Als
         Zusatzinformation wird ein Array übergeben, dessen erstes Element die Statusinformation
         zu diesem Nachrichtenaustausch darstellt ({@link org.kapott.hbci.status.HBCIMsgStatus})
         und dessen zweites Element die neue System-ID ist. */
-    STATUS_INIT_SYSID_DONE,
+    INIT_SYSID_DONE,
     /** Kernel-Status: hole UPD. Kann nur während der Passport-Initialisierung
         ({@link org.kapott.hbci.manager.HBCIHandler#HBCIHandler(String,org.kapott.hbci.passport.HBCIPassport)})
         auftreten und zeigt an, dass die UPD von der Bank abgeholt werden müssen,
         weil sie noch nicht lokal vorhanden sind. Es werden keine zusätzlichen
         Informationen übergeben.  */
-    STATUS_INIT_UPD,
+    INIT_UPD,
     /** Kernel-Status: UPD aktualisiert. Dieser Status-Callback tritt nach dem expliziten
-        Abholen der UPD ({@link #STATUS_INIT_UPD}) auf und kann auch nach einer
+        Abholen der UPD ({@link #INIT_UPD}) auf und kann auch nach einer
         Dialog-Initialisierung auftreten, wenn dabei eine neue UPD vom Kreditinstitut
         empfangen wurde. Als Zusatzinformation wird ein <code>Properties</code>-Objekt
         mit den neuen UPD übergeben. */
-    STATUS_INIT_UPD_DONE,
+    INIT_UPD_DONE,
     /** Kernel-Status: sperre Nutzerschlüssel. Dieser Status-Callback wird erzeugt, wenn
         <em>HBCI4Java</em> einen Auftrag zur Sperrung der aktuellen Nutzerschlüssel
         generiert. Es werden keine Zusatzinformationen übergeben. */
-    STATUS_LOCK_KEYS,
+    LOCK_KEYS,
     /** Kernel-Status: Nutzerschlüssel gesperrt. Dieser Callback tritt auf, nachdem die
         Antwort auf die Nachricht "Sperren der Nutzerschlüssel" eingetroffen ist. Ein
         Auftreten dieses Callbacks ist keine Garantie dafür, dass die Schlüsselsperrung
         erfolgreich abgelaufen ist. Es wird der Status
         des Nachrichtenaustauschs ({@link org.kapott.hbci.status.HBCIMsgStatus})
         als Zusatzinformation übergeben. */
-    STATUS_LOCK_KEYS_DONE,
+    LOCK_KEYS_DONE,
     /** Kernel-Status: aktualisiere Signatur-ID. Dieser Status-Callback wird erzeugt, wenn
         <em>HBCI4Java</em> die Signatur-ID, die für das RDH-Verfahren benötigt
         wird, synchronisiert. Der Callback kann nur beim Initialisieren eines Passports
         (siehe {@link org.kapott.hbci.manager.HBCIHandler#HBCIHandler(String,org.kapott.hbci.passport.HBCIPassport)})
         auftreten. Es werden keine Zusatzinformationen übergeben. */
-    STATUS_INIT_SIGID,
+    INIT_SIGID,
     /** Kernel-Status: Signatur-ID aktualisiert. Dieser Callback tritt auf, wenn im Zuge der
-        Synchronisierung ({@link #STATUS_INIT_SIGID}) eine Signatur-ID empfangen wurde. Als
+        Synchronisierung ({@link #INIT_SIGID}) eine Signatur-ID empfangen wurde. Als
         Zusatzinformation wird ein Array übergeben, dessen erstes Element die Statusinformation
         zu diesem Nachrichtenaustausch darstellt ({@link org.kapott.hbci.status.HBCIMsgStatus})
         und dessen zweites Element die neue Signatur-ID (ein Long-Objekt) ist. */
-    STATUS_INIT_SIGID_DONE,
+    INIT_SIGID_DONE,
     /** Kernel-Status: Starte Dialog-Initialisierung. Dieser Status-Callback zeigt an, dass
         <em>HBCI4Java</em> eine Dialog-Initialisierung startet. Es werden keine
         zusätzlichen Informationen übergeben. */
-    STATUS_DIALOG_INIT,
+    DIALOG_INIT,
     /** Kernel-Status: Dialog-Initialisierung ausgeführt. Dieser Callback tritt nach dem
         Durchführen der Dialog-Initialisierung auf. Als
         Zusatzinformation wird ein Array übergeben, dessen erstes Element die Statusinformation
         zu diesem Nachrichtenaustausch darstellt ({@link org.kapott.hbci.status.HBCIMsgStatus})
         und dessen zweites Element die neue Dialog-ID ist. */
-    STATUS_DIALOG_INIT_DONE,
+    DIALOG_INIT_DONE,
     /** Kernel-Status: Beende Dialog. Wird ausgelöst, wenn <em>HBCI4Java</em> den
         aktuellen Dialog beendet. Es werden keine zusätzlichen Daten übergeben. */
-    STATUS_DIALOG_END,
+    DIALOG_END,
     /** Kernel-Status: Dialog beendet. Wird ausgeführt, wenn der HBCI-Dialog tatsächlich
         beendet ist. Es wird der Status
         des Nachrichtenaustauschs ({@link org.kapott.hbci.status.HBCIMsgStatus})
         als Zusatzinformation übergeben. */
-    STATUS_DIALOG_END_DONE,
+    DIALOG_END_DONE,
     /** Kernel-Status: Erzeuge HBCI-Nachricht. Dieser Callback zeigt an, dass <em>HBCI4Java</em>
         gerade eine HBCI-Nachricht erzeugt. Es wird der Name der Nachricht als zusätzliches
         Objekt übergeben. */
-    STATUS_MSG_CREATE,
+    MSG_CREATE,
     /** Kernel-Status: Signiere HBCI-Nachricht. Dieser Callback wird aufgerufen, wenn
         <em>HBCI4Java</em> die ausgehende HBCI-Nachricht signiert. Es werden keine
         zusätzlichen Informationen übergeben. */
-    STATUS_MSG_SIGN,
+    MSG_SIGN,
     /** Kernel-Status: Verschlüssele HBCI-Nachricht. Wird aufgerufen, wenn <em>HBCI4Java</em>
         die ausgehende HBCI-Nachricht verschlüsselt. Es werden keine zusätzlichen
         Informationen übergeben. */
-    STATUS_MSG_CRYPT,
+    MSG_CRYPT,
     /** Kernel-Status: Sende HBCI-Nachricht (bei diesem Callback ist das
         <code>passport</code>-Objekt immer <code>null</code>). Wird aufgerufen,
         wenn die erzeugte HBCI-Nachricht an den HBCI-Server versandt wird. Es werden
         keine zusätzlichen Informationen übergeben. */
-    STATUS_MSG_SEND,
+    MSG_SEND,
     /** Kernel-Status: Entschlüssele HBCI-Nachricht. Wird aufgerufen, wenn die empfangene
         HBCI-Nachricht von <em>HBCI4Java</em> entschlüsselt wird. Es werden keine
         zusätzlichen Informationen übergeben. */
-    STATUS_MSG_DECRYPT,
+    MSG_DECRYPT,
     /** Kernel-Status: Überprüfe digitale Signatur der Nachricht. Wird aufgerufen, wenn
         <em>HBCI4Java</em> die digitale Signatur der empfangenen Antwortnachricht
         überprüft. Es werden keine zusätzlichen Informationen übergeben. */
-    STATUS_MSG_VERIFY,
+    MSG_VERIFY,
     /** Kernel-Status: Empfange HBCI-Antwort-Nachricht (bei diesem Callback ist das
         <code>passport</code>-Objekt immer <code>null</code>). Wird aufgerufen, wenn
         die Antwort-HBCI-Nachricht vom HBCI-Server empfangen wird. Es werden keine
         zusätzlichen Informationen übergeben. */
-    STATUS_MSG_RECV,
+    MSG_RECV,
     /** Kernel-Status: Parse HBCI-Antwort-Nachricht (bei diesem Callback ist das
         <code>passport</code>-Objekt immer <code>null</code>). Wird aufgerufen, wenn
         <em>HBCI4Java</em> versucht, die empfangene Nachricht zu parsen. Es wird
         der Name der erwarteten Nachricht als zusätzliche Information übergeben. */
-    STATUS_MSG_PARSE,
+    MSG_PARSE,
     /**
      * @deprecated
      **/
-    STATUS_SEND_INFOPOINT_DATA,
+    SEND_INFOPOINT_DATA,
     /**
      * Wird aufgerufen unmittelbar bevor die HBCI-Nachricht an den Server gesendet wird.
      * Als zusaetzliche Information wird die zu sendende Nachricht als String uebergeben.
      * Sie kann dann z.Bsp. in einem Log gesammelt werden, welches ausschliesslich
-     * (zusammen mit {@link #STATUS_MSG_RAW_RECV}) die gesendeten und
+     * (zusammen mit {@link #MSG_RAW_RECV}) die gesendeten und
      * empfangenen rohen HBCI-Nachrichten enthaelt. Sinnvoll zum Debuggen der Kommunikation
      * mit der Bank.
      */
-    STATUS_MSG_RAW_SEND,
+    MSG_RAW_SEND,
     /**
      * Wird aufgerufen unmittelbar nachdem die HBCI-Nachricht vom Server empfangen wurde.
      * Als zusaetzliche Information wird die empfangene Nachricht als String uebergeben.
      * Sie kann dann z.Bsp. in einem Log gesammelt werden, welches ausschliesslich
-     * (zusammen mit {@link #STATUS_MSG_RAW_SEND}) die gesendeten und
+     * (zusammen mit {@link #MSG_RAW_SEND}) die gesendeten und
      * empfangenen rohen HBCI-Nachrichten enthaelt. Sinnvoll zum Debuggen der Kommunikation
      * mit der Bank.
      */
-    STATUS_MSG_RAW_RECV,
+    MSG_RAW_RECV,
     /**
      * Wie STATUS_MSG_RAW_RECV - jedoch noch vor der Entschluesselung der Daten.
      * Abhaengig vom HBCI-Verfahren kann die Nachricht aber auch hier bereits entschluesselt
@@ -563,7 +563,7 @@ public interface HBCICallback
      * Konkret ist das PIN/TAN. Bei Schluesseldatei und Chipkarte hingegen ist die
      * Message zu diesem Zeitpunkt hier noch verschluesselt.
      */
-    STATUS_MSG_RAW_RECV_ENCRYPTED
+    MSG_RAW_RECV_ENCRYPTED
   }
 
     /** Wird aufgerufen, wenn der HBCI-Kernel eine Log-Ausgabe

--- a/src/main/java/org/kapott/hbci/callback/HBCICallback.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallback.java
@@ -109,11 +109,11 @@ public interface HBCICallback
         <p>Beim Auftreten dieses Callbacks muss die Anwendung also die gerade empfangenen Schlüsseldaten der
         Bank (öffentlicher Signier-/Chiffrierschlüssel) geeignet anzeigen (Exponent, Modulus, Hash-Wert) und
         den Anwender auffordern, diese Daten mit denen aus dem INI-Brief zu vergleichen. Dieser Callback
-        erwartet als Rückgabedaten einen Boolean-Wert (siehe {@link ResponseType#TYPE_BOOLEAN}). Sind die Daten
+        erwartet als Rückgabedaten einen Boolean-Wert (siehe {@link ResponseType#BOOLEAN}). Sind die Daten
         in Ordnung, so muss die Callback-Methode einen leeren String in dem Rückgabedaten-StringBuffer
         zurückgeben, ansonsten füllt sie den StringBuffer mit einem beliebigen nichtleeren String (siehe dazu
         {@link #callback(org.kapott.hbci.passport.HBCIPassport,int,String, ResponseType,StringBuffer)} und
-        die Beschreibung des Rückgabe-Datentyps {@link ResponseType#TYPE_BOOLEAN})).</p>
+        die Beschreibung des Rückgabe-Datentyps {@link ResponseType#BOOLEAN})).</p>
         <p>Da im Moment keine dokumentierten Methoden zur Verfügung stehen, um aus einem Passport die
         entsprechenden Schlüsseldaten zum Anzeigen zu extrahieren, wird folgendes Vorgehen empfohlen:
         die Anwendung erzeugt eine HBCICallback-Klasse, die von einer der bereits vorhandenen 
@@ -200,7 +200,7 @@ public interface HBCICallback
         im <code>retData</code> Rückgabedaten-Objekt ein leerer String zurückgegeben wird, oder er kann
         erzwingen, dass <em>HBCI4Java</em> tatsächlich abbricht, indem ein nicht-leerer String im
         <code>retData</code>-Objekt zurückgegen wird. Siehe dazu auch die Beschreibung des
-        Rückgabe-Datentyps {@link ResponseType#TYPE_BOOLEAN}.</p>
+        Rückgabe-Datentyps {@link ResponseType#BOOLEAN}.</p>
         <p>Das Ignorieren eines Fehlers kann dazu führen, dass <em>HBCI4Java</em> später trotzdem eine
         Exception erzeugt, z.B. weil der Fehler in einem bestimmten Submodul doch nicht einfach ignoriert
         werden kann, oder es kann auch dazu führen, dass Aufträge von der Bank nicht angenommen werden usw.
@@ -361,11 +361,11 @@ public interface HBCICallback
     enum ResponseType
     {
         /** erwarteter Datentyp der Antwort: keiner (keine Antwortdaten erwartet) */
-        TYPE_NONE,
+        NONE,
         /** erwarteter Datentyp der Antwort: geheimer Text (bei Eingabe nicht anzeigen) */
-        TYPE_SECRET,
+        SECRET,
         /** erwarteter Datentyp der Antwort: "normaler" Text */
-        TYPE_TEXT,
+        TEXT,
         /**
          * <p>erwarteter Datentyp der Antwort: ja/nein, true/false, weiter/abbrechen
          * oder ähnlich. Da das Rückgabedatenobjekt immer ein <code>StringBuffer</code> ist, wird hier folgende Kodierung
@@ -378,7 +378,7 @@ public interface HBCICallback
          * <p>Siehe dazu auch die Hinweise in der Paketbeschreibung zum Paket
          * <code>org.kapott.hbci.callback</code>.</p>
          */
-        TYPE_BOOLEAN
+        BOOLEAN
     }
     
     /** Kernel-Status: Erzeuge Auftrag zum Versenden. Als Zusatzinformation 

--- a/src/main/java/org/kapott/hbci/callback/HBCICallback.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallback.java
@@ -40,6 +40,7 @@ import org.kapott.hbci.passport.HBCIPassport;
     Methode dieses Passwort direkt zurückgeben, ohne den Anwender erneut danach zu fragen. </p>*/ 
 public interface HBCICallback
 {
+    enum Reason {
     /** Ursache des Callback-Aufrufes: Chipkarte benötigt (im Chipkartenterminal). Dieser Callback
         tritt auf, wenn der HBCI-Kernel auf das Einlegen der HBCI-Chipkarte in den Chipkartenleser
         wartet. Als Reaktion auf diesen Callback darf nur eine entsprechende Aufforderung o.ä.
@@ -47,14 +48,14 @@ public interface HBCICallback
         "Warten" auf die Chipkarte sowie das Erkennen, dass eine Chipkarte eingelegt wurde,
         wird von <em>HBCI4Java</em> übernommen. Ist das Einlegen der Chipkarte abgeschlossen, so wird ein
         weiterer Callback mit dem Code <code>HAVE_CHIPCARD</code> erzeugt.*/
-    public final static int NEED_CHIPCARD=2;
+    NEED_CHIPCARD,
     /** Ursache des Callback-Aufrufes: PIN-Eingabe am Chipkartenterminal erwartet. Dieser Callback
         zeigt an, dass der Anwender jetzt die HBCI-PIN am Chipkartenterminal eingeben muss. Hier
         gilt das gleiche wie beim Code <code>NEED_CHIPCARD</code>: Die Callback-Methode darf hier
         nur eine entsprechende Meldung o.ä. anzeigen und muss dann sofort zurückkehren -- <em>HBCI4Java</em> erledigt die
         eigentliche Entgegennahme der PIN. Wurde die PIN eingegeben (oder die Eingabe abgebrochen),
         so wird ein weiterer Callback-Aufruf mit dem Code <code>HAVE_HARDPIN</code> erzeugt. */
-    public final static int NEED_HARDPIN=3;
+    NEED_HARDPIN,
     /** Ursache des Callback-Aufrufes: PIN-Eingabe über Computer-Tastatur benötigt. Alternativ zum
         Callback <code>NEED_HARDPIN</code> kann dieser Callback auftreten, wenn die direkte PIN-Eingabe
         am Chipkartenterminal nicht möglich oder deaktiviert ist. In diesem Fall muss die PIN
@@ -62,25 +63,25 @@ public interface HBCICallback
         ein, welche über diesen Callback-Aufruf an den HBCI-Kernel übergeben wird. Der Kernel
         übermittelt die PIN anschließend zur Verifikation an die Chipkarte. In diesem Falle gibt es
         keinen weiteren Callback-Aufruf, wenn die PIN-Verifikation abgeschlossen ist! */
-    public final static int NEED_SOFTPIN=4;
+    NEED_SOFTPIN,
     /** Ursache des Callback-Aufrufes: PIN-Eingabe über Chipkartenterminal abgeschlossen. Dieser Callback
         tritt auf, wenn die direkte PIN-Eingabe am Chipkartenleser abgeschlossen (oder abgebrochen) ist.
         Dieser Aufruf kann dazu genutzt werden, evtl. angezeigte Meldungsfenster ("Bitte jetzt PIN eingeben")
         wieder zu schließen. */ 
-    public final static int HAVE_HARDPIN=5;
+    HAVE_HARDPIN,
     /** Ursache des Callback-Aufrufes: Chipkarte wurde in Chipkartenterminal eingelegt. Dieser Callback
         tritt auf, wenn das Einlegen der Chipkarte in den Chipkartenleser abgeschlossen (oder abgebrochen) ist.
         Dieser Aufruf kann dazu genutzt werden, evtl. angezeigte Meldungsfenster ("Bitte jetzt Karte einlegen einlegen")
         wieder zu schließen. */
-    public final static int HAVE_CHIPCARD=6;
+    HAVE_CHIPCARD,
     /** Ursache des Callback-Aufrufes: Länderkennzeichen der Bankverbindung benötigt. Der Kernel benötigt
         für ein neu zu erstellendes Passport-Medium das Länderkennzeichen der Bank, für die dieses
         Passport benutzt werden soll. Da es sich i.d.R. um deutsche Banken handelt, kann die Callback-Routine
         hier immer "DE" zurückgeben, anstatt tatsächlich auf eine Nutzereingabe zu warten. */
-    public final static int NEED_COUNTRY=7;
+    NEED_COUNTRY,
     /** Ursache des Callback-Aufrufes: Bankleitzahl der Bank benötigt. Für ein neu zu erstellendes Passport-Medium
         wird die Bankleitzahl der Bank benötigt, für die dieses Passport verwendet werden soll. */
-    public final static int NEED_BLZ=8;
+    NEED_BLZ,
     /** Ursache des Callback-Aufrufes: Netzwerkadresse des HBCI-Servers benötigt. Es wird die Hostadresse
         benötigt, unter welcher der HBCI-Server der Bank zu erreichen ist. Dieses Callback tritt nur auf,
         wenn der Kernel ein neues Passport-Medium erzeugt. Bei RDH- bzw. DDV-Passports wird hier eine
@@ -88,16 +89,16 @@ public interface HBCICallback
         erwartet, unter der der HBCI-PIN/TAN-Handler auf entsprechende HTTPS-Requests reagiert. Dabei
         muss das Prefix "<code>https://</code>" weggelassen werden (also beispielsweise 
         "<code>www.hbci-kernel.de/pintan/PinTanServlet</code>").*/
-    public final static int NEED_HOST=9;
+    NEED_HOST,
     /** Ursache des Callback-Aufrufes: TCP-Port, auf dem der HBCI-Server arbeitet (3000), benötigt. Dieser
         Callback tritt nur auf, wenn ein neues Passport-Medium vom Kernel erzeugt wird. Da die TCP-Portnummer
         für HBCI-Server immer "3000" ist, kann dieser Wert direkt von der Callback-Methode zurückgegeben
         werden, anstatt auf eine Nutzereingabe zu warten. */
-    public final static int NEED_PORT=10;
+    NEED_PORT,
     /** Ursache des Callback-Aufrufes: Nutzerkennung für HBCI-Zugang benötigt. Wird beim Anlegen eines neuen
         Passport-Mediums und manchmal beim erstmaligen Benutzen einer DDV-Chipkarte erzeugt, wenn auf der
         Chipkarte die Benutzerkennung noch nicht gespeichert ist. */
-    public final static int NEED_USERID=11;
+    NEED_USERID,
     /** Ursache des Callback-Aufrufes: Bestätigung für neue Instituts-Schlüssel benötigt (INI-Brief-Vergleich).
         Dieser Callback tritt nur bei Verwendung des RDH-Verfahrens auf. Bei einer Dialoginitialisierung
         versucht <em>HBCI4Java</em>, die öffentlichen Schlüssel des Kreditinstitutes zu aktualisieren. Werden
@@ -112,7 +113,7 @@ public interface HBCICallback
         erwartet als Rückgabedaten einen Boolean-Wert (siehe {@link ResponseType#BOOLEAN}). Sind die Daten
         in Ordnung, so muss die Callback-Methode einen leeren String in dem Rückgabedaten-StringBuffer
         zurückgeben, ansonsten füllt sie den StringBuffer mit einem beliebigen nichtleeren String (siehe dazu
-        {@link #callback(org.kapott.hbci.passport.HBCIPassport,int,String, ResponseType,StringBuffer)} und
+        {@link #callback(org.kapott.hbci.passport.HBCIPassport,Reason,String,ResponseType,StringBuffer)} und
         die Beschreibung des Rückgabe-Datentyps {@link ResponseType#BOOLEAN})).</p>
         <p>Da im Moment keine dokumentierten Methoden zur Verfügung stehen, um aus einem Passport die
         entsprechenden Schlüsseldaten zum Anzeigen zu extrahieren, wird folgendes Vorgehen empfohlen:
@@ -122,7 +123,7 @@ public interface HBCICallback
         auf, so kann die Anwendung mit <code>super.callback(...)</code> die bereits implementierte
         Version des entsprechenden Handlers aufrufen. In diesen Default-Implementationen werden zur Zeit
         nicht dokumentierte Passport-Funktionen benutzt, um die Schlüsseldaten zu extrahieren.</p>*/
-    public final static int NEED_NEW_INST_KEYS_ACK=12;
+    NEED_NEW_INST_KEYS_ACK,
     /** Ursache des Callback-Aufrufes: neue Nutzerschlüssel generiert (INI-Brief erforderlich). Dieser Callback
         tritt nur bei Verwendung von RDH-Passports auf. Wird ein RDH-Passport neu erstellt, so werden für
         den Bankkunden neue Schlüssel für die Signierung und Verschlüsselung der HBCI-Nachrichten erzeugt.
@@ -141,30 +142,30 @@ public interface HBCICallback
         Wird ein HBCI-Dialog begonnen, obwohl die Bank die neuen Schlüssel noch nicht aktiviert hat,
         wird der HBCI-Server mit einer entsprechenden Fehlermeldung beim Initialisieren des HBCI-Dialoges
         antworten.</p>*/
-    public final static int HAVE_NEW_MY_KEYS=13;
+    HAVE_NEW_MY_KEYS,
     /** Ursache des Callback-Aufrufes: Institutsnachricht erhalten. Tritt dieser Callback auf, so enthält
         der <code>msg</code>-Parameter der <code>callback</code>-Methode (siehe
-        {@link #callback(org.kapott.hbci.passport.HBCIPassport,int,String,ResponseType,StringBuffer)} einen
+        {@link #callback(org.kapott.hbci.passport.HBCIPassport,Reason,String,ResponseType,StringBuffer)} einen
         String, den die Bank als Kreditinstitutsnachricht an den Kunden gesandt hat. Diese Nachricht sollte
         dem Anwender i.d.R. angezeigt werden. <em>HBCI4Java</em> erwartet auf diesen Callback keine Antwortdaten. */
-    public final static int HAVE_INST_MSG=14;
+    HAVE_INST_MSG,
     /** Ursache des Callback-Aufrufes: Chipkarte soll aus Chipkartenterminal entfernt werden. Dieser Callback
         wird zur Zeit noch nicht benutzt. */
-    public final static int NEED_REMOVE_CHIPCARD=15;
+    NEED_REMOVE_CHIPCARD,
     /** Ursache des Callback-Aufrufes: PIN für PIN/TAN-Verfahren benötigt. Dieser Callback tritt nur bei
         Verwendung von PIN/TAN-Passports auf. Benötigt <em>HBCI4Java</em> die PIN, um die digitale Signatur zu
         erzeugen, wird sie über diesen Callback abgefragt. */
-    public final static int NEED_PT_PIN=16;
+    NEED_PT_PIN,
     /** Ursache des Callback-Aufrufes: eine TAN für PIN/TAN-Verfahren benötigt. Dieser Callback tritt nur bei
         Verwendung von PIN/TAN-Passports auf. Benötigt <em>HBCI4Java</em> eine TAN, um eine digitale Signatur zu
         erzeugen, wird sie über diesen Callback abgefragt. */
-    public final static int NEED_PT_TAN=17;
+    NEED_PT_TAN,
     /** Ursache des Callback-Aufrufes: Kunden-ID für HBCI-Zugang benötigt. Dieser Callback tritt nur beim
         Erzeugen eines neuen Passports auf. <em>HBCI4Java</em> benötigt die Kunden-ID, die das Kreditinstitut
         dem Bankkunden zugewiesen hat (steht meist in dem Brief mit den Zugangsdaten). Hat eine Bank einem
         Kunden keine separate Kunden-ID zugewiesen, so muss an dieser Stelle die Benutzer-Kennung (User-ID)
         zurückgegeben werden. */
-    public final static int NEED_CUSTOMERID=18;
+    NEED_CUSTOMERID,
     /** <p>Ursache des Callback-Aufrufes: Fehler beim Verifizieren einer Kontonummer mit Hilfe
         des jeweiligen Prüfzifferverfahrens. Tritt dieser Callback auf, so hat <em>HBCI4Java</em>
         festgestellt, dass eine verwendete Kontonummer den Prüfziffercheck der dazugehörigen Bank nicht
@@ -188,7 +189,7 @@ public interface HBCICallback
         Prüfzifferfehler, der dabei entdeckt wird, wird dieser Callback erzeugt.<br/>
         Tritt beim Überprüfen einer IBAN ein Fehler auf, wird statt dessen
         {@link #HAVE_IBAN_ERROR} als Callback-Reason verwendet. */
-    public final static int HAVE_CRC_ERROR=19;
+    HAVE_CRC_ERROR,
     /** <p>Ursache des Callback-Aufrufes: Es ist ein Fehler aufgetreten, der auf Wunsch 
         des Anwenders ignoriert werden kann. Durch Setzen bestimmter Kernel-Parameter 
         (siehe {@link org.kapott.hbci.manager.HBCIUtils#setParam(String,String)}) kann
@@ -205,21 +206,21 @@ public interface HBCICallback
         Exception erzeugt, z.B. weil der Fehler in einem bestimmten Submodul doch nicht einfach ignoriert
         werden kann, oder es kann auch dazu führen, dass Aufträge von der Bank nicht angenommen werden usw.
         Es wird aber in jedem Fall eine entsprechende Fehlermeldung erzeugt.</p> */
-    public final static int HAVE_ERROR=20;
+    HAVE_ERROR,
     
     /** Ursache des Callback-Aufrufes: Passwort für das Einlesen der Schlüsseldatei
         benötigt. Dieser Callback tritt beim Laden eines Passport-Files auf, um nach dem 
         Passwort für die Entschlüsselung zu fragen. 
         ACHTUNG: Die folgenden Zeichen duerfen NICHT im Passwort enthalten sein: ß´°§üÜöäÖÄ
         */
-    public final static int NEED_PASSPHRASE_LOAD=21;
+    NEED_PASSPHRASE_LOAD,
     /** Ursache des Callback-Aufrufes: Passwort für das Erzeugen der Schlüsseldatei
         benötigt. Dieser Callback tritt beim Erzeugen eines neuen Passport-Files bzw. beim
         Ändern der Passphrase für eine Schlüsseldatei auf, um nach dem 
         Passwort für die Verschlüsselung zu fragen.
         ACHTUNG: Die folgenden Zeichen duerfen NICHT im Passwort enthalten sein: ß´°§üÜöäÖÄ
          */
-    public final static int NEED_PASSPHRASE_SAVE=22;
+    NEED_PASSPHRASE_SAVE,
     /** <p>Ursache des Callback-Aufrufes: Auswahl eines Eintrages aus einer SIZ-RDH-Datei
         benötigt. Dieser Callback tritt nur bei Verwendung der Passport-Variante
         SIZRDHFile auf. In einer SIZ-RDH-Schlüsseldatei können mehrere HBCI-Zugangsdatensätze
@@ -241,7 +242,7 @@ public interface HBCICallback
         Der Anwender muss sich also zwischen den Datensätzen "09950003;Kunde-001",
         "01234567;Kunde8" und "8765432;7364634564564" entscheiden. Je nach Auswahl
         muss in <code>retData</code> dann jeweils "0", "1" oder "4" zurückgegeben werden.</p>*/
-    public final static int NEED_SIZENTRY_SELECT=23;
+    NEED_SIZENTRY_SELECT,
     /** <p>Ursache des Callback-Aufrufes: es wird eine Netz-Verbindung zum HBCI-Server benötigt.
         Dieser Callback wird erzeugt, bevor <em>HBCI4Java</em> eine Verbindung zum HBCI-Server
         aufbaut. Bei Client-Anwendungen, die mit einer Dialup-Verbindung zum Internet arbeiten,
@@ -259,14 +260,14 @@ public interface HBCICallback
         <code>NEED_CONNECTION</code>/<code>CLOSE_CONNECTION</code> aufgerufen. Evtl.
         sollte der Callback-Handler der Anwendung in diesem Fall also entsprechende
         Maßnahmen treffen.</p> */
-    public final static int NEED_CONNECTION=24;
+    NEED_CONNECTION,
     /** Ursache des Callback-Aufrufes: die Netzwerk-Verbindung zum HBCI-Server wird nicht länger
         benötigt. Dieser Callback wird aufgerufen, sobald <em>HBCI4Java</em> die Kommunikation
         mit dem HBCI-Server vorläufig beendet hat. Dieser Callback kann zusammen mit dem
         Callback {@link #NEED_CONNECTION} benutzt werden, um für Clients mit Dialup-Verbindungen
         die Online-Zeiten zu optimieren. Bei diesem Callback werden keine Rückgabedaten
         erwartet */
-    public final static int CLOSE_CONNECTION=25;
+    CLOSE_CONNECTION,
     /** <p>Ursache des Callback-Aufrufes: es wird die Bezeichnung des zu verwendenden
         Datenfilters benötigt. Mögliche Filterbezeichnungen sind "<code>None</code>"
         (kein Filter) und "<code>Base64</code>" (Daten BASE64-kodieren). Die
@@ -278,7 +279,7 @@ public interface HBCICallback
         Wenn bei dessen Verwendung aber keine Antwortdaten von der Bank empfangen
         werden, dann sollte die andere Variante (<code>None</code>) ausprobiert 
         werden.</p> */
-    public final static int NEED_FILTER=26;
+    NEED_FILTER,
     
     /** <p>Ursache des Callbacks: bei Verwendung von HBCI-PIN/TAN muss eines der
      * unterstützten Verfahren ausgewählt werden. Seit FinTS-3.0 gibt es mehrere
@@ -293,7 +294,7 @@ public interface HBCICallback
      * PIN/TAN-Verfahren. Die Callback-Methode muss die ID des vom Anwender
      * ausgewählten PIN/TAN-Verfahrens anschließend in <code>retData</code>
      * zurückgeben.</p> */
-    public final static int NEED_PT_SECMECH=27;
+    NEED_PT_SECMECH,
     
     /** Ursache des Callbacks: es wird ein Nutzername für die Authentifizierung
      * am Proxy-Server benötigt. Wird für die HTTPS-Verbindungen bei HBCI-PIN/TAN 
@@ -301,7 +302,7 @@ public interface HBCICallback
      * Authentifizierung, so wird über diesen Callback nach dem Nutzernamen
      * gefragt, falls dieser nicht schon durch den Kernel-Parameter
      * <code>client.passport.PinTan.proxyuser</code> gesetzt wurde */
-    public final static int NEED_PROXY_USER=28;
+    NEED_PROXY_USER,
 
     /** Ursache des Callbacks: es wird ein Passwort für die Authentifizierung
      * am Proxy-Server benötigt. Wird für die HTTPS-Verbindungen bei HBCI-PIN/TAN 
@@ -309,7 +310,7 @@ public interface HBCICallback
      * Authentifizierung, so wird über diesen Callback nach dem Passwort
      * gefragt, falls dieses nicht schon durch den Kernel-Parameter
      * <code>client.passport.PinTan.proxypass</code> gesetzt wurde */
-    public final static int NEED_PROXY_PASS=29;
+    NEED_PROXY_PASS,
     
     /** Ursache des Callbacks: beim Überprüfen einer IBAN ist ein Fehler aufgetreten.
      * in <code>retData</code> wird die fehlerhafte IBAN übergeben. Der Nutzer
@@ -320,19 +321,19 @@ public interface HBCICallback
      * wird der Callback erneut erzeugt. Das geht so lange, bis entweder der
      * Prüfsummencheck erfolgreich war oder bis die IBAN vom Nutzer nicht verändert
      * wird. Siehe dazu auch {@link #HAVE_CRC_ERROR}. */
-    public final static int HAVE_IBAN_ERROR=30;
+    HAVE_IBAN_ERROR,
     
     /** 
      * @deprecated
      **/
-    public final static int NEED_INFOPOINT_ACK=31;
+    NEED_INFOPOINT_ACK,
     
     /** <p>Ursache des Callbacks: bei Verwendung von HBCI-PIN/TAN muss
      * die Bezeichnung des TAN-Mediums eingegeben werden. Bei smsTAN ist
      * das z.Bsp. der Alias-Name des Mobiltelefons, wie er bei der Bank
      * hinterlegt wurde. Dieser Name wird verwendet, damit die SMS mit
      * der TAN an mehrere Mobiltelefone schicken kann. */
-    public final static int NEED_PT_TANMEDIA=32;
+    NEED_PT_TANMEDIA,
 
     /**
      * Ursache des Callback-Aufrufes: eine Photo-TAN für PIN/TAN-Verfahren benötigt. Dieser
@@ -341,7 +342,7 @@ public interface HBCICallback
      * des Bildes inclusive Angaben zum Bildformat. HBCI4Java enthaelt eine Klasse "MatrixCode",
      * mit dem diese Daten dann gelesen werden koennen.
      **/
-    public final static int NEED_PT_PHOTOTAN=33;
+    NEED_PT_PHOTOTAN,
 
     /**
      * Ursache des Callback-Aufrufes: eine QR-Code-TAN für PIN/TAN-Verfahren benötigt. Dieser
@@ -349,14 +350,15 @@ public interface HBCICallback
      * Im Callback wird im StringBuffer der Wert aus dem HHDuc uebergeben. Das sind die Roh-Daten
      * des Bildes. HBCI4Java enthaelt eine Klasse "QRCode", mit dem diese Daten dann gelesen werden koennen.
      **/
-    public final static int NEED_PT_QRTAN=34;
+    NEED_PT_QRTAN,
 
     /** <p>Ursache des Callbacks: falsche PIN eingegeben */
-    public final static int WRONG_PIN=40;
+    WRONG_PIN,
     
     /** <p>Ursache des Callbacks: Dialogantwort 3072 der GAD - UserID und CustomerID werden ausgetauscht */
     /** <p>im Parameter retData stehen die neuen Daten im Format UserID|CustomerID drin */
-    public final static int USERID_CHANGED=41;
+    USERID_CHANGED
+    }
 
     enum ResponseType
     {
@@ -598,7 +600,7 @@ public interface HBCICallback
         ablegen (keinen neuen StringBuffer erzeugen, sondern den Inhalt von <code>retData</code>
         überschreiben!). Bei einigen Callbacks übergibt <em>HBCI4Java</em> einen vorgeschlagenen
         default-Wert für die Nutzereingabe im <em>retData</em>-Objekt. Diese Tatsache ist
-        besonders bei der Auswertung des Callbacks {@link #HAVE_CRC_ERROR} zu beachten!
+        besonders bei der Auswertung des Callbacks {@link Reason#HAVE_CRC_ERROR} zu beachten!
         @param passport enthält das Passport-Objekt, bei dessen Benutzung der
         Callback erzeugt wurde. Falls also in einer Anwendung mehrere
         Passport-Objekte gleichzeitig benutzt werden, so kann anhand
@@ -627,13 +629,13 @@ public interface HBCICallback
         abgelegt werden. Beim Aufruf der Callback-Methode von <em>HBCI4Java</em> wird dieser
         StringBuffer u.U. mit einem vorgeschlagenen default-Wert für die Nutzereingabe
         gefüllt. */
-    public void callback(HBCIPassport passport,int reason,String msg,ResponseType datatype,StringBuffer retData);
+    public void callback(HBCIPassport passport,Reason reason,String msg,ResponseType datatype,StringBuffer retData);
     
     /** Wird vom HBCI-Kernel aufgerufen, um einen bestimmten Status der
         Abarbeitung bekanntzugeben.
         @param passport gibt an, welches Passport (und damit welches HBCIHandle)
         benutzt wurde, als der Callback erzeugt wurde (siehe auch
-        {@link #callback(org.kapott.hbci.passport.HBCIPassport,int,String,ResponseType,StringBuffer)}).
+        {@link #callback(org.kapott.hbci.passport.HBCIPassport,Reason,String,ResponseType,StringBuffer)}).
         @param statusTag gibt an, welche Stufe der Abarbeitung gerade erreicht
         wurde (alle oben beschriebenen Konstanten, die mit <code>STATUS_</code>
         beginnen)
@@ -658,11 +660,11 @@ public interface HBCICallback
      * dass sie für alle Callbacks, die synchron behandelt werden sollen,
      * <code>true</code> zurückgibt.</p>
      * <p>Die übergebenen Parameter entsprechen denen der Methode
-     * {@link #callback(HBCIPassport,int,String,ResponseType,StringBuffer)}. Der
+     * {@link #callback(HBCIPassport,Reason,String,ResponseType,StringBuffer)}. Der
      * Rückgabewert gibt ab, ob dieser Callback synchron (<code>true</code>) oder
      * asynchron (<code>false</code>) behandelt werden soll.</p>
      * <p>Mehr Informationen dazu in der Datei <code>README.ThreadedCallbacks</code>.</p> */
-    public boolean useThreadedCallback(HBCIPassport passport,int reason,
+    public boolean useThreadedCallback(HBCIPassport passport,Reason reason,
                                        String msg,ResponseType datatype,
                                        StringBuffer retData);
 }

--- a/src/main/java/org/kapott/hbci/callback/HBCICallback.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallback.java
@@ -385,178 +385,176 @@ public interface HBCICallback
         {@link org.kapott.hbci.callback}.</p> */
     BOOLEAN
   }
-    
-    /** Kernel-Status: Erzeuge Auftrag zum Versenden. Als Zusatzinformation 
-        wird bei diesem Callback das <code>HBCIJob</code>-Objekt des 
+
+  enum Status
+  {
+    /** Kernel-Status: Erzeuge Auftrag zum Versenden. Als Zusatzinformation
+        wird bei diesem Callback das <code>HBCIJob</code>-Objekt des
         Auftrages übergeben, dessen Auftragsdaten gerade erzeugt werden. */
-    public final static int STATUS_SEND_TASK=1;
+    STATUS_SEND_TASK,
     /** Kernel-Status: Auftrag gesendet. Tritt auf, wenn zu einem bestimmten Job
         Auftragsdaten empfangen und ausgewertet wurden. Als Zusatzinformation wird
         das <code>HBCIJob</code>-Objekt des jeweiligen Auftrages übergeben. */
-    public final static int STATUS_SEND_TASK_DONE=2;
+    STATUS_SEND_TASK_DONE,
     /** Kernel-Status: hole BPD. Kann nur während der Passport-Initialisierung
         ({@link org.kapott.hbci.manager.HBCIHandler#HBCIHandler(String,org.kapott.hbci.passport.HBCIPassport)})
         auftreten und zeigt an, dass die BPD von der Bank abgeholt werden müssen,
         weil sie noch nicht lokal vorhanden sind. Es werden keine zusätzlichen
         Informationen übergeben. */
-    public final static int STATUS_INST_BPD_INIT=3;
+    STATUS_INST_BPD_INIT,
     /** Kernel-Status: BPD aktualisiert. Dieser Status-Callback tritt nach dem expliziten
         Abholen der BPD ({@link #STATUS_INST_BPD_INIT}) auf und kann auch nach einer
         Dialog-Initialisierung auftreten, wenn dabei eine neue BPD vom Kreditinstitut
         empfangen wurde. Als Zusatzinformation wird ein <code>Properties</code>-Objekt
-        mit den neuen BPD übergeben.*/
-    public final static int STATUS_INST_BPD_INIT_DONE=4;
+        mit den neuen BPD übergeben. */
+    STATUS_INST_BPD_INIT_DONE,
     /** Kernel-Status: hole Institutsschlüssel. Dieser Status-Callback zeigt an, dass
         <em>HBCI4Java</em> die öffentlichen Schlüssel des Kreditinstitutes abholt.
-        Dieser Callback kann nur beim Initialisieren eines Passportes (siehe 
+        Dieser Callback kann nur beim Initialisieren eines Passportes (siehe
         {@link org.kapott.hbci.manager.HBCIHandler#HBCIHandler(String,org.kapott.hbci.passport.HBCIPassport)})
         und bei Verwendung von RDH als Sicherheitsverfahren auftreten. Es werden keine
         zusätzlichen Informationen übergeben. */
-    public final static int STATUS_INST_GET_KEYS=5;
+    STATUS_INST_GET_KEYS,
     /** Kernel-Status: Institutsschlüssel aktualisiert. Dieser Callback tritt
         auf, wenn <em>HBCI4Java</em> neue öffentliche Schlüssel der Bank
         empfangen hat. Dieser Callback kann nach dem expliziten Anfordern der
         neuen Schlüssel ({@link #STATUS_INST_GET_KEYS}) oder nach einer Dialog-Initialisierung
         auftreten, wenn das Kreditinstitut neue Schlüssel übermittelt hat. Es
         werden keine zusätzlichen Informationen übergeben. */
-    public final static int STATUS_INST_GET_KEYS_DONE=6;
+    STATUS_INST_GET_KEYS_DONE,
     /** Kernel-Status: Sende Nutzerschlüssel. Wird erzeugt, wenn <em>HBCI4Java</em>
         neue Schlüssel des Anwenders an die Bank versendet. Das tritt beim erstmaligen
         Einrichten eines RDH-Passportes bzw. nach dem manuellen Erzeugen neuer
         RDH-Schlüssel auf. Es werden keine zusätzlichen Informationen übergeben. */
-    public final static int STATUS_SEND_KEYS=7;
+    STATUS_SEND_KEYS,
     /** Kernel-Status: Nutzerschlüssel gesendet. Dieser Callback zeigt an, dass die RDH-Schlüssel
         des Anwenders an die Bank versandt wurden. Der Erfolg dieser Aktion kann nicht
         allein durch das Auftreten dieses Callbacks angenommen werden! Es wird der Status
         des Nachrichtenaustauschs ({@link org.kapott.hbci.status.HBCIMsgStatus})
         als Zusatzinformation übergeben. */
-    public final static int STATUS_SEND_KEYS_DONE=8;
+    STATUS_SEND_KEYS_DONE,
     /** Kernel-Status: aktualisiere System-ID. Dieser Status-Callback wird erzeugt, wenn
         <em>HBCI4Java</em> die System-ID, die für das RDH-Verfahren benötigt
         wird, synchronisiert. Der Callback kann nur beim Initialisieren eines Passports
         (siehe {@link org.kapott.hbci.manager.HBCIHandler#HBCIHandler(String,org.kapott.hbci.passport.HBCIPassport)})
         auftreten. Es werden keine Zusatzinformationen übergeben. */
-    public final static int STATUS_INIT_SYSID=9;
+    STATUS_INIT_SYSID,
     /** Kernel-Status: System-ID aktualisiert. Dieser Callback tritt auf, wenn im Zuge der
         Synchronisierung ({@link #STATUS_INIT_SYSID}) eine System-ID empfangen wurde. Als
         Zusatzinformation wird ein Array übergeben, dessen erstes Element die Statusinformation
-        zu diesem Nachrichtenaustausch darstellt ({@link org.kapott.hbci.status.HBCIMsgStatus}) 
+        zu diesem Nachrichtenaustausch darstellt ({@link org.kapott.hbci.status.HBCIMsgStatus})
         und dessen zweites Element die neue System-ID ist. */
-    public final static int STATUS_INIT_SYSID_DONE=10;
+    STATUS_INIT_SYSID_DONE,
     /** Kernel-Status: hole UPD. Kann nur während der Passport-Initialisierung
         ({@link org.kapott.hbci.manager.HBCIHandler#HBCIHandler(String,org.kapott.hbci.passport.HBCIPassport)})
         auftreten und zeigt an, dass die UPD von der Bank abgeholt werden müssen,
         weil sie noch nicht lokal vorhanden sind. Es werden keine zusätzlichen
         Informationen übergeben.  */
-    public final static int STATUS_INIT_UPD=11;
+    STATUS_INIT_UPD,
     /** Kernel-Status: UPD aktualisiert. Dieser Status-Callback tritt nach dem expliziten
         Abholen der UPD ({@link #STATUS_INIT_UPD}) auf und kann auch nach einer
         Dialog-Initialisierung auftreten, wenn dabei eine neue UPD vom Kreditinstitut
         empfangen wurde. Als Zusatzinformation wird ein <code>Properties</code>-Objekt
         mit den neuen UPD übergeben. */
-    public final static int STATUS_INIT_UPD_DONE=12;
+    STATUS_INIT_UPD_DONE,
     /** Kernel-Status: sperre Nutzerschlüssel. Dieser Status-Callback wird erzeugt, wenn
         <em>HBCI4Java</em> einen Auftrag zur Sperrung der aktuellen Nutzerschlüssel
         generiert. Es werden keine Zusatzinformationen übergeben. */
-    public final static int STATUS_LOCK_KEYS=13;
+    STATUS_LOCK_KEYS,
     /** Kernel-Status: Nutzerschlüssel gesperrt. Dieser Callback tritt auf, nachdem die
         Antwort auf die Nachricht "Sperren der Nutzerschlüssel" eingetroffen ist. Ein
         Auftreten dieses Callbacks ist keine Garantie dafür, dass die Schlüsselsperrung
         erfolgreich abgelaufen ist. Es wird der Status
         des Nachrichtenaustauschs ({@link org.kapott.hbci.status.HBCIMsgStatus})
         als Zusatzinformation übergeben. */
-    public final static int STATUS_LOCK_KEYS_DONE=14;
+    STATUS_LOCK_KEYS_DONE,
     /** Kernel-Status: aktualisiere Signatur-ID. Dieser Status-Callback wird erzeugt, wenn
         <em>HBCI4Java</em> die Signatur-ID, die für das RDH-Verfahren benötigt
         wird, synchronisiert. Der Callback kann nur beim Initialisieren eines Passports
         (siehe {@link org.kapott.hbci.manager.HBCIHandler#HBCIHandler(String,org.kapott.hbci.passport.HBCIPassport)})
         auftreten. Es werden keine Zusatzinformationen übergeben. */
-    public final static int STATUS_INIT_SIGID=15;
+    STATUS_INIT_SIGID,
     /** Kernel-Status: Signatur-ID aktualisiert. Dieser Callback tritt auf, wenn im Zuge der
         Synchronisierung ({@link #STATUS_INIT_SIGID}) eine Signatur-ID empfangen wurde. Als
         Zusatzinformation wird ein Array übergeben, dessen erstes Element die Statusinformation
-        zu diesem Nachrichtenaustausch darstellt ({@link org.kapott.hbci.status.HBCIMsgStatus}) 
-        und dessen zweites Element die neue Signatur-ID (ein Long-Objekt) ist.*/
-    public final static int STATUS_INIT_SIGID_DONE=16;
+        zu diesem Nachrichtenaustausch darstellt ({@link org.kapott.hbci.status.HBCIMsgStatus})
+        und dessen zweites Element die neue Signatur-ID (ein Long-Objekt) ist. */
+    STATUS_INIT_SIGID_DONE,
     /** Kernel-Status: Starte Dialog-Initialisierung. Dieser Status-Callback zeigt an, dass
         <em>HBCI4Java</em> eine Dialog-Initialisierung startet. Es werden keine
         zusätzlichen Informationen übergeben. */
-    public final static int STATUS_DIALOG_INIT=17;
+    STATUS_DIALOG_INIT,
     /** Kernel-Status: Dialog-Initialisierung ausgeführt. Dieser Callback tritt nach dem
         Durchführen der Dialog-Initialisierung auf. Als
         Zusatzinformation wird ein Array übergeben, dessen erstes Element die Statusinformation
-        zu diesem Nachrichtenaustausch darstellt ({@link org.kapott.hbci.status.HBCIMsgStatus}) 
+        zu diesem Nachrichtenaustausch darstellt ({@link org.kapott.hbci.status.HBCIMsgStatus})
         und dessen zweites Element die neue Dialog-ID ist. */
-    public final static int STATUS_DIALOG_INIT_DONE=18;
+    STATUS_DIALOG_INIT_DONE,
     /** Kernel-Status: Beende Dialog. Wird ausgelöst, wenn <em>HBCI4Java</em> den
         aktuellen Dialog beendet. Es werden keine zusätzlichen Daten übergeben. */
-    public final static int STATUS_DIALOG_END=19;
+    STATUS_DIALOG_END,
     /** Kernel-Status: Dialog beendet. Wird ausgeführt, wenn der HBCI-Dialog tatsächlich
         beendet ist. Es wird der Status
         des Nachrichtenaustauschs ({@link org.kapott.hbci.status.HBCIMsgStatus})
-        als Zusatzinformation übergeben.*/
-    public final static int STATUS_DIALOG_END_DONE=20;
+        als Zusatzinformation übergeben. */
+    STATUS_DIALOG_END_DONE,
     /** Kernel-Status: Erzeuge HBCI-Nachricht. Dieser Callback zeigt an, dass <em>HBCI4Java</em>
         gerade eine HBCI-Nachricht erzeugt. Es wird der Name der Nachricht als zusätzliches
         Objekt übergeben. */
-    public final static int STATUS_MSG_CREATE=21;
+    STATUS_MSG_CREATE,
     /** Kernel-Status: Signiere HBCI-Nachricht. Dieser Callback wird aufgerufen, wenn
         <em>HBCI4Java</em> die ausgehende HBCI-Nachricht signiert. Es werden keine
         zusätzlichen Informationen übergeben. */
-    public final static int STATUS_MSG_SIGN=22;
+    STATUS_MSG_SIGN,
     /** Kernel-Status: Verschlüssele HBCI-Nachricht. Wird aufgerufen, wenn <em>HBCI4Java</em>
         die ausgehende HBCI-Nachricht verschlüsselt. Es werden keine zusätzlichen
         Informationen übergeben. */
-    public final static int STATUS_MSG_CRYPT=23;
+    STATUS_MSG_CRYPT,
     /** Kernel-Status: Sende HBCI-Nachricht (bei diesem Callback ist das
         <code>passport</code>-Objekt immer <code>null</code>). Wird aufgerufen,
         wenn die erzeugte HBCI-Nachricht an den HBCI-Server versandt wird. Es werden
         keine zusätzlichen Informationen übergeben. */
-    public final static int STATUS_MSG_SEND=24;
+    STATUS_MSG_SEND,
     /** Kernel-Status: Entschlüssele HBCI-Nachricht. Wird aufgerufen, wenn die empfangene
         HBCI-Nachricht von <em>HBCI4Java</em> entschlüsselt wird. Es werden keine
         zusätzlichen Informationen übergeben. */
-    public final static int STATUS_MSG_DECRYPT=25;
+    STATUS_MSG_DECRYPT,
     /** Kernel-Status: Überprüfe digitale Signatur der Nachricht. Wird aufgerufen, wenn
         <em>HBCI4Java</em> die digitale Signatur der empfangenen Antwortnachricht
         überprüft. Es werden keine zusätzlichen Informationen übergeben. */
-    public final static int STATUS_MSG_VERIFY=26;
+    STATUS_MSG_VERIFY,
     /** Kernel-Status: Empfange HBCI-Antwort-Nachricht (bei diesem Callback ist das
         <code>passport</code>-Objekt immer <code>null</code>). Wird aufgerufen, wenn
         die Antwort-HBCI-Nachricht vom HBCI-Server empfangen wird. Es werden keine
         zusätzlichen Informationen übergeben. */
-    public final static int STATUS_MSG_RECV=27;
+    STATUS_MSG_RECV,
     /** Kernel-Status: Parse HBCI-Antwort-Nachricht (bei diesem Callback ist das
-        <code>passport</code>-Objekt immer <code>null</code>). Wird aufgerufen, wenn 
+        <code>passport</code>-Objekt immer <code>null</code>). Wird aufgerufen, wenn
         <em>HBCI4Java</em> versucht, die empfangene Nachricht zu parsen. Es wird
         der Name der erwarteten Nachricht als zusätzliche Information übergeben. */
-    public final static int STATUS_MSG_PARSE=28;    
-    
-    /** 
+    STATUS_MSG_PARSE,
+    /**
      * @deprecated
      **/
-    public final static int STATUS_SEND_INFOPOINT_DATA=29;
-
+    STATUS_SEND_INFOPOINT_DATA,
     /**
      * Wird aufgerufen unmittelbar bevor die HBCI-Nachricht an den Server gesendet wird.
      * Als zusaetzliche Information wird die zu sendende Nachricht als String uebergeben.
      * Sie kann dann z.Bsp. in einem Log gesammelt werden, welches ausschliesslich
-     * (zusammen mit {@link HBCICallback#STATUS_MSG_RAW_RECV}) die gesendeten und
+     * (zusammen mit {@link #STATUS_MSG_RAW_RECV}) die gesendeten und
      * empfangenen rohen HBCI-Nachrichten enthaelt. Sinnvoll zum Debuggen der Kommunikation
      * mit der Bank.
      */
-    public final static int STATUS_MSG_RAW_SEND=30;
-    
+    STATUS_MSG_RAW_SEND,
     /**
      * Wird aufgerufen unmittelbar nachdem die HBCI-Nachricht vom Server empfangen wurde.
      * Als zusaetzliche Information wird die empfangene Nachricht als String uebergeben.
      * Sie kann dann z.Bsp. in einem Log gesammelt werden, welches ausschliesslich
-     * (zusammen mit {@link HBCICallback#STATUS_MSG_RAW_SEND}) die gesendeten und
+     * (zusammen mit {@link #STATUS_MSG_RAW_SEND}) die gesendeten und
      * empfangenen rohen HBCI-Nachrichten enthaelt. Sinnvoll zum Debuggen der Kommunikation
      * mit der Bank.
      */
-    public final static int STATUS_MSG_RAW_RECV=31;
-    
+    STATUS_MSG_RAW_RECV,
     /**
      * Wie STATUS_MSG_RAW_RECV - jedoch noch vor der Entschluesselung der Daten.
      * Abhaengig vom HBCI-Verfahren kann die Nachricht aber auch hier bereits entschluesselt
@@ -565,7 +563,8 @@ public interface HBCICallback
      * Konkret ist das PIN/TAN. Bei Schluesseldatei und Chipkarte hingegen ist die
      * Message zu diesem Zeitpunkt hier noch verschluesselt.
      */
-    public final static int STATUS_MSG_RAW_RECV_ENCRYPTED=32;
+    STATUS_MSG_RAW_RECV_ENCRYPTED
+  }
 
     /** Wird aufgerufen, wenn der HBCI-Kernel eine Log-Ausgabe
         erzeugt. <em>HBCI4Java</em> gibt Logging-Ausgaben nicht selbst auf
@@ -647,11 +646,11 @@ public interface HBCICallback
         String, der zusätzliche Informationen im Klartext enthält. Welche Informationen
         das jeweils sind, ist der Beschreibung zu den einzelnen <code>STATUS_*</code>-Tag-Konstanten
         zu entnehmen. */
-    public void status(HBCIPassport passport,int statusTag,Object[] o);
+    public void status(HBCIPassport passport,Status statusTag,Object[] o);
     
-    /** Kurzform für {@link #status(HBCIPassport, int, Object[])} für den Fall,
+    /** Kurzform für {@link #status(HBCIPassport, Status, Object[])} für den Fall,
      *  dass das <code>Object[]</code> nur ein einziges Objekt enthält */
-    public void status(HBCIPassport passport,int statusTag,Object o);
+    public void status(HBCIPassport passport,Status statusTag,Object o);
     
     /** <p>Legt fest, ob ein Callback asynchron oder über den threaded-callback-Mechanismus
      * behandelt werden soll. Im "Normalfall" gibt diese Methode <code>false</code>

--- a/src/main/java/org/kapott/hbci/callback/HBCICallbackIOStreams.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallbackIOStreams.java
@@ -355,7 +355,7 @@ public class HBCICallbackIOStreams
     /** Wird diese Methode von <em>HBCI4Java</em> aufgerufen, so wird der aktuelle
     Bearbeitungsschritt (mit evtl. vorhandenen zusätzlichen Informationen)
     auf <code>outStream</code> ausgegeben. */
-    public synchronized void status(HBCIPassport passport, int statusTag, Object[] o) {
+    public synchronized void status(HBCIPassport passport, Status statusTag, Object[] o) {
         switch (statusTag) {
             case STATUS_INST_BPD_INIT:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_REC_INST_DATA"));
@@ -460,7 +460,7 @@ public class HBCICallbackIOStreams
                 break;
 
             default:
-                throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("STATUS_INVALID",Integer.toString(statusTag)));
+                throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("STATUS_INVALID", statusTag));
         }
     }
 }

--- a/src/main/java/org/kapott/hbci/callback/HBCICallbackIOStreams.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallbackIOStreams.java
@@ -357,105 +357,105 @@ public class HBCICallbackIOStreams
     auf <code>outStream</code> ausgegeben. */
     public synchronized void status(HBCIPassport passport, Status statusTag, Object[] o) {
         switch (statusTag) {
-            case STATUS_INST_BPD_INIT:
+            case INST_BPD_INIT:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_REC_INST_DATA"));
                 break;
-            case STATUS_INST_BPD_INIT_DONE:
+            case INST_BPD_INIT_DONE:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_REC_INST_DATA_DONE",passport.getBPDVersion()));
                 break;
-            case STATUS_INST_GET_KEYS:
+            case INST_GET_KEYS:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_REC_INST_KEYS"));
                 break;
-            case STATUS_INST_GET_KEYS_DONE:
+            case INST_GET_KEYS_DONE:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_REC_INST_KEYS_DONE"));
                 break;
-            case STATUS_SEND_KEYS:
+            case SEND_KEYS:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_SEND_MY_KEYS"));
                 break;
-            case STATUS_SEND_KEYS_DONE:
+            case SEND_KEYS_DONE:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_SEND_MY_KEYS_DONE"));
                 getOutStream().println("status: "+((HBCIMsgStatus)o[0]).toString());
                 break;
-            case STATUS_INIT_SYSID:
+            case INIT_SYSID:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_REC_SYSID"));
                 break;
-            case STATUS_INIT_SYSID_DONE:
+            case INIT_SYSID_DONE:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_REC_SYSID_DONE",o[1].toString()));
                 getOutStream().println("status: "+((HBCIMsgStatus)o[0]).toString());
                 break;
-            case STATUS_INIT_SIGID:
+            case INIT_SIGID:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_REC_SIGID"));
                 break;
-            case STATUS_INIT_SIGID_DONE:
+            case INIT_SIGID_DONE:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_REC_SIGID_DONE",o[1].toString()));
                 getOutStream().println("status: "+((HBCIMsgStatus)o[0]).toString());
                 break;
-            case STATUS_INIT_UPD:
+            case INIT_UPD:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_REC_USER_DATA"));
                 break;
-            case STATUS_INIT_UPD_DONE:
+            case INIT_UPD_DONE:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_REC_USER_DATA_DONE",passport.getUPDVersion()));
                 break;
-            case STATUS_LOCK_KEYS:
+            case LOCK_KEYS:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_USR_LOCK"));
                 break;
-            case STATUS_LOCK_KEYS_DONE:
+            case LOCK_KEYS_DONE:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_USR_LOCK_DONE"));
                 getOutStream().println("status: "+((HBCIMsgStatus)o[0]).toString());
                 break;
-            case STATUS_DIALOG_INIT:
+            case DIALOG_INIT:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_DIALOG_INIT"));
                 break;
-            case STATUS_DIALOG_INIT_DONE:
+            case DIALOG_INIT_DONE:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_DIALOG_INIT_DONE",o[1]));
                 getOutStream().println("status: "+((HBCIMsgStatus)o[0]).toString());
                 break;
-            case STATUS_SEND_TASK:
+            case SEND_TASK:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_DIALOG_NEW_JOB",((HBCIJob)o[0]).getName()));
                 break;
-            case STATUS_SEND_TASK_DONE:
+            case SEND_TASK_DONE:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_DIALOG_JOB_DONE",((HBCIJob)o[0]).getName()));
                 break;
-            case STATUS_DIALOG_END:
+            case DIALOG_END:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_DIALOG_END"));
                 break;
-            case STATUS_DIALOG_END_DONE:
+            case DIALOG_END_DONE:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_DIALOG_END_DONE"));
                 getOutStream().println("status: "+((HBCIMsgStatus)o[0]).toString());
                 break;
-            case STATUS_MSG_CREATE:
+            case MSG_CREATE:
                 getOutStream().println("  "+HBCIUtilsInternal.getLocMsg("STATUS_MSG_CREATE",o[0].toString()));
                 break;
-            case STATUS_MSG_SIGN:
+            case MSG_SIGN:
                 getOutStream().println("  "+HBCIUtilsInternal.getLocMsg("STATUS_MSG_SIGN"));
                 break;
-            case STATUS_MSG_CRYPT:
+            case MSG_CRYPT:
                 getOutStream().println("  "+HBCIUtilsInternal.getLocMsg("STATUS_MSG_CRYPT"));
                 break;
-            case STATUS_MSG_SEND:
+            case MSG_SEND:
                 getOutStream().println("  "+HBCIUtilsInternal.getLocMsg("STATUS_MSG_SEND"));
                 break;
-            case STATUS_MSG_RECV:
+            case MSG_RECV:
                 getOutStream().println("  "+HBCIUtilsInternal.getLocMsg("STATUS_MSG_RECV"));
                 break;
-            case STATUS_MSG_PARSE:
+            case MSG_PARSE:
                 getOutStream().println("  "+HBCIUtilsInternal.getLocMsg("STATUS_MSG_PARSE",o[0].toString()+")"));
                 break;
-            case STATUS_MSG_DECRYPT:
+            case MSG_DECRYPT:
                 getOutStream().println("  "+HBCIUtilsInternal.getLocMsg("STATUS_MSG_DECRYPT"));
                 break;
-            case STATUS_MSG_VERIFY:
+            case MSG_VERIFY:
                 getOutStream().println("  "+HBCIUtilsInternal.getLocMsg("STATUS_MSG_VERIFY"));
                 break;
-            case STATUS_MSG_RAW_SEND:
+            case MSG_RAW_SEND:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_MSG_RAW_SEND",o[0].toString()));
                 break;
 
-            case STATUS_MSG_RAW_RECV:
+            case MSG_RAW_RECV:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_MSG_RAW_RECV",o[0].toString()));
                 break;
 
-            case STATUS_MSG_RAW_RECV_ENCRYPTED:
+            case MSG_RAW_RECV_ENCRYPTED:
                 getOutStream().println(HBCIUtilsInternal.getLocMsg("STATUS_MSG_RAW_RECV_ENCRYPTED",o[0].toString()));
                 break;
 

--- a/src/main/java/org/kapott/hbci/callback/HBCICallbackIOStreams.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallbackIOStreams.java
@@ -114,7 +114,7 @@ public class HBCICallbackIOStreams
     entsprechende Aufforderung ausgegeben. Bei Callbacks, die eine Eingabe vom
     Nutzer erwarten, wird die entsprechende Eingabeaufforderung ausgegeben und die
     Eingabe vom <code>inStream</code> gelesen.*/
-    public void callback(HBCIPassport passport, int reason, String msg, ResponseType datatype, StringBuffer retData)
+    public void callback(HBCIPassport passport, Reason reason, String msg, ResponseType datatype, StringBuffer retData)
     {
         getOutStream().println(HBCIUtilsInternal.getLocMsg("CALLB_PASS_IDENT",passport.getClientData("init")));
         
@@ -131,7 +131,7 @@ public class HBCICallbackIOStreams
                     getOutStream().flush();
                     
                     st=this.readLine();
-                    if (reason==NEED_PASSPHRASE_SAVE) {
+                    if (reason==Reason.NEED_PASSPHRASE_SAVE) {
                         getOutStream().print(msg+" (again): ");
                         getOutStream().flush();
                         
@@ -186,9 +186,9 @@ public class HBCICallbackIOStreams
                     if (st.length()==0)
                         st=retData.toString();
                     
-                    if (reason==NEED_BLZ) {
+                    if (reason==Reason.NEED_BLZ) {
                     	logfilter.addSecretData(st,"X",LogFilter.FILTER_MOST);
-                    } else if (reason==NEED_USERID || reason==NEED_CUSTOMERID || reason==NEED_PROXY_USER) {
+                    } else if (reason==Reason.NEED_USERID || reason==Reason.NEED_CUSTOMERID || reason==Reason.NEED_PROXY_USER) {
                     	logfilter.addSecretData(st,"X",LogFilter.FILTER_IDS);
                     }
                     
@@ -345,7 +345,7 @@ public class HBCICallbackIOStreams
                     break;
     
                 default:
-                    throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("EXCMSG_CALLB_UNKNOWN",Integer.toString(reason)));
+                    throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("EXCMSG_CALLB_UNKNOWN", reason));
             }
         } catch (Exception e) {
             throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("EXCMSG_CALLB_ERR"),e);

--- a/src/main/java/org/kapott/hbci/callback/HBCICallbackIOStreams.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallbackIOStreams.java
@@ -114,7 +114,7 @@ public class HBCICallbackIOStreams
     entsprechende Aufforderung ausgegeben. Bei Callbacks, die eine Eingabe vom
     Nutzer erwarten, wird die entsprechende Eingabeaufforderung ausgegeben und die
     Eingabe vom <code>inStream</code> gelesen.*/
-    public void callback(HBCIPassport passport, int reason, String msg, int datatype, StringBuffer retData) 
+    public void callback(HBCIPassport passport, int reason, String msg, ResponseType datatype, StringBuffer retData)
     {
         getOutStream().println(HBCIUtilsInternal.getLocMsg("CALLB_PASS_IDENT",passport.getClientData("init")));
         

--- a/src/main/java/org/kapott/hbci/callback/HBCICallbackNative.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallbackNative.java
@@ -138,7 +138,7 @@ public final class HBCICallbackNative
     /** Externe, von der Anwendung zu implementierende Methode. Es muss von der
      * nativen Anwendung eine Methode mit dieser Signatur erzeugt und via JNI
      * registriert werden. */
-    public native void nativeCallback(HBCIPassport passport,int reason,String msg,ResponseType datatype,StringBuffer retData);
+    public native void nativeCallback(HBCIPassport passport,Reason reason,String msg,ResponseType datatype,StringBuffer retData);
 
     /** Externe, von der Anwendung zu implementierende Methode. Es muss von der
      * nativen Anwendung eine Methode mit dieser Signatur erzeugt und via JNI
@@ -151,7 +151,7 @@ public final class HBCICallbackNative
         nativeLog(msg,level,date,trace);
     }
 
-    public void callback(HBCIPassport passport,int reason,final String msg,ResponseType datatype,StringBuffer retData)
+    public void callback(HBCIPassport passport,Reason reason,final String msg,ResponseType datatype,StringBuffer retData)
     {
         nativeCallback(passport,reason,msg,datatype,retData);
     }

--- a/src/main/java/org/kapott/hbci/callback/HBCICallbackNative.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallbackNative.java
@@ -143,7 +143,7 @@ public final class HBCICallbackNative
     /** Externe, von der Anwendung zu implementierende Methode. Es muss von der
      * nativen Anwendung eine Methode mit dieser Signatur erzeugt und via JNI
      * registriert werden. */
-    public native void nativeStatus(HBCIPassport passport,int statusTag,Object[] o);
+    public native void nativeStatus(HBCIPassport passport,Status statusTag,Object[] o);
 
     /** Ruft {@link #nativeLog(String, int, Date, StackTraceElement)} auf. */
     public synchronized void log(String msg,int level,Date date,StackTraceElement trace)
@@ -156,8 +156,8 @@ public final class HBCICallbackNative
         nativeCallback(passport,reason,msg,datatype,retData);
     }
     
-    /** Ruft {@link #nativeStatus(HBCIPassport, int, Object[])} auf. */
-    public synchronized void status(HBCIPassport passport,int statusTag,Object[] o)
+    /** Ruft {@link #nativeStatus(HBCIPassport, Status, Object[])} auf. */
+    public synchronized void status(HBCIPassport passport,Status statusTag,Object[] o)
     {
         nativeStatus(passport,statusTag,o);
     }

--- a/src/main/java/org/kapott/hbci/callback/HBCICallbackNative.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallbackNative.java
@@ -138,7 +138,7 @@ public final class HBCICallbackNative
     /** Externe, von der Anwendung zu implementierende Methode. Es muss von der
      * nativen Anwendung eine Methode mit dieser Signatur erzeugt und via JNI
      * registriert werden. */
-    public native void nativeCallback(HBCIPassport passport,int reason,String msg,int datatype,StringBuffer retData);
+    public native void nativeCallback(HBCIPassport passport,int reason,String msg,ResponseType datatype,StringBuffer retData);
 
     /** Externe, von der Anwendung zu implementierende Methode. Es muss von der
      * nativen Anwendung eine Methode mit dieser Signatur erzeugt und via JNI
@@ -151,8 +151,7 @@ public final class HBCICallbackNative
         nativeLog(msg,level,date,trace);
     }
 
-    /** Ruft {@link #nativeCallback(HBCIPassport, int, String, int, StringBuffer)} auf. */
-    public void callback(HBCIPassport passport,int reason,final String msg,int datatype,StringBuffer retData)
+    public void callback(HBCIPassport passport,int reason,final String msg,ResponseType datatype,StringBuffer retData)
     {
         nativeCallback(passport,reason,msg,datatype,retData);
     }

--- a/src/main/java/org/kapott/hbci/callback/HBCICallbackSwing.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallbackSwing.java
@@ -103,7 +103,7 @@ public class HBCICallbackSwing
         passports=new Hashtable<HBCIPassport, Hashtable<String, Object>>();
     }
     
-    public void callback(final HBCIPassport passport,int reason,String msg,int datatype,StringBuffer retData)
+    public void callback(final HBCIPassport passport,Reason reason,String msg,int datatype,StringBuffer retData)
     {
         if (msg==null)
             msg="";
@@ -117,7 +117,7 @@ public class HBCICallbackSwing
             currentData.put("msgcounter",new Integer(0));
             passports.put(passport,currentData);
         }
-        currentData.put("reason",new Integer(reason));
+        currentData.put("reason", reason);
         currentData.put("msg",msg);
         
         if (retData!=null)
@@ -239,7 +239,7 @@ public class HBCICallbackSwing
                     break;
 
                 default:
-                    throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("EXCMSG_CALLB_UNKNOWN",Integer.toString(reason)));
+                    throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("EXCMSG_CALLB_UNKNOWN", reason));
             }
         } catch (Exception e) {
             throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("EXCMSG_CALLB_ERR"),e);
@@ -290,7 +290,7 @@ public class HBCICallbackSwing
             mainbox.add(Box.createVerticalStrut(8));
             
             JPasswordField tempinput=null;
-            if (((Integer)currentData.get("reason")).intValue()==NEED_PASSPHRASE_SAVE) {
+            if (currentData.get("reason")==Reason.NEED_PASSPHRASE_SAVE) {
                 tempinput=new JPasswordField(10);
                 mainbox.add(tempinput);
                 mainbox.add(Box.createVerticalStrut(8));

--- a/src/main/java/org/kapott/hbci/callback/HBCICallbackThreaded.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallbackThreaded.java
@@ -39,7 +39,7 @@ import org.kapott.hbci.passport.HBCIPassportInternal;
  * dafür, dass {@link org.kapott.hbci.manager.HBCIHandler#executeThreaded() hbci.executeThreaded()}
  * terminiert.</p>
  * <p>Mehr Informationen sind in der Datei <code>README.ThreadedCallbacks</code>
- * sowie unter {@link HBCICallback#useThreadedCallback(HBCIPassport, int, String, int, StringBuffer)}
+ * sowie unter {@link HBCICallback#useThreadedCallback(HBCIPassport, int, String, ResponseType, StringBuffer)}
  * zu finden.</p> */
 public final class HBCICallbackThreaded 
     extends AbstractHBCICallback
@@ -70,7 +70,7 @@ public final class HBCICallbackThreaded
      * {@link org.kapott.hbci.manager.HBCIHandler#executeThreaded()} terminiert
      * und Callback-Info-Daten zurückgibt. */
     public void callback(HBCIPassport passport,int reason,String msg,
-                         int datatype,StringBuffer retData)
+                         ResponseType datatype,StringBuffer retData)
     {
         HBCIUtils.log("hbci thread: threaded callback received", HBCIUtils.LOG_DEBUG);
         
@@ -96,7 +96,7 @@ public final class HBCICallbackThreaded
                 callbackData.put("passport",passport);
                 callbackData.put("reason",new Integer(reason));
                 callbackData.put("msg",msg);
-                callbackData.put("dataType",new Integer(datatype));
+                callbackData.put("dataType",datatype);
                 callbackData.put("retData",retData);
                 
                 sync_main.setData("callbackData",callbackData);

--- a/src/main/java/org/kapott/hbci/callback/HBCICallbackThreaded.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallbackThreaded.java
@@ -135,7 +135,7 @@ public final class HBCICallbackThreaded
     }
 
     /** Aufruf wird an das "normale" Callback-Objekt weitergereicht. */
-    public void status(HBCIPassport passport,int statusTag,Object[] o)
+    public void status(HBCIPassport passport,Status statusTag,Object[] o)
     {
         // TODO das hier evtl. auch in den threaded-workflow aufnehmen?
         realCallback.status(passport,statusTag,o);

--- a/src/main/java/org/kapott/hbci/callback/HBCICallbackThreaded.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallbackThreaded.java
@@ -39,7 +39,7 @@ import org.kapott.hbci.passport.HBCIPassportInternal;
  * dafür, dass {@link org.kapott.hbci.manager.HBCIHandler#executeThreaded() hbci.executeThreaded()}
  * terminiert.</p>
  * <p>Mehr Informationen sind in der Datei <code>README.ThreadedCallbacks</code>
- * sowie unter {@link HBCICallback#useThreadedCallback(HBCIPassport, int, String, ResponseType, StringBuffer)}
+ * sowie unter {@link HBCICallback#useThreadedCallback(HBCIPassport, Reason, String, ResponseType, StringBuffer)}
  * zu finden.</p> */
 public final class HBCICallbackThreaded 
     extends AbstractHBCICallback
@@ -69,7 +69,7 @@ public final class HBCICallbackThreaded
      * von dieser Methode behandelt, in dem der entsprechende Aufruf von
      * {@link org.kapott.hbci.manager.HBCIHandler#executeThreaded()} terminiert
      * und Callback-Info-Daten zurückgibt. */
-    public void callback(HBCIPassport passport,int reason,String msg,
+    public void callback(HBCIPassport passport,Reason reason,String msg,
                          ResponseType datatype,StringBuffer retData)
     {
         HBCIUtils.log("hbci thread: threaded callback received", HBCIUtils.LOG_DEBUG);
@@ -94,7 +94,7 @@ public final class HBCICallbackThreaded
                 Hashtable<String, Object> callbackData=new Hashtable<String, Object>();
                 callbackData.put("method","callback");
                 callbackData.put("passport",passport);
-                callbackData.put("reason",new Integer(reason));
+                callbackData.put("reason", reason);
                 callbackData.put("msg",msg);
                 callbackData.put("dataType",datatype);
                 callbackData.put("retData",retData);

--- a/src/main/java/org/kapott/hbci/callback/HBCICallbackUnsupported.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallbackUnsupported.java
@@ -21,7 +21,7 @@ import org.kapott.hbci.passport.HBCIPassport;
 public class HBCICallbackUnsupported implements HBCICallback {
 
     @Override
-    public void callback(HBCIPassport passport, int reason, String msg, ResponseType datatype, StringBuffer retData)
+    public void callback(HBCIPassport passport, Reason reason, String msg, ResponseType datatype, StringBuffer retData)
     {
         throw new UnsupportedOperationException("Unexpected HBCI callback");
     }
@@ -45,7 +45,7 @@ public class HBCICallbackUnsupported implements HBCICallback {
     }
 
     @Override
-    public boolean useThreadedCallback(HBCIPassport passport, int reason, String msg, ResponseType datatype, StringBuffer retData)
+    public boolean useThreadedCallback(HBCIPassport passport, Reason reason, String msg, ResponseType datatype, StringBuffer retData)
     {
         throw new UnsupportedOperationException("Unexpected HBCI callback");
     }

--- a/src/main/java/org/kapott/hbci/callback/HBCICallbackUnsupported.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallbackUnsupported.java
@@ -21,7 +21,7 @@ import org.kapott.hbci.passport.HBCIPassport;
 public class HBCICallbackUnsupported implements HBCICallback {
 
     @Override
-    public void callback(HBCIPassport passport, int reason, String msg, int datatype, StringBuffer retData)
+    public void callback(HBCIPassport passport, int reason, String msg, ResponseType datatype, StringBuffer retData)
     {
         throw new UnsupportedOperationException("Unexpected HBCI callback");
     }
@@ -45,7 +45,7 @@ public class HBCICallbackUnsupported implements HBCICallback {
     }
 
     @Override
-    public boolean useThreadedCallback(HBCIPassport passport, int reason, String msg, int datatype, StringBuffer retData)
+    public boolean useThreadedCallback(HBCIPassport passport, int reason, String msg, ResponseType datatype, StringBuffer retData)
     {
         throw new UnsupportedOperationException("Unexpected HBCI callback");
     }

--- a/src/main/java/org/kapott/hbci/callback/HBCICallbackUnsupported.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallbackUnsupported.java
@@ -27,13 +27,13 @@ public class HBCICallbackUnsupported implements HBCICallback {
     }
 
     @Override
-    public void status(HBCIPassport passport, int statusTag, Object o)
+    public void status(HBCIPassport passport, Status statusTag, Object o)
     {
         throw new UnsupportedOperationException("Unexpected HBCI callback");
     }
 
     @Override
-    public void status(HBCIPassport passport, int statusTag, Object[] o)
+    public void status(HBCIPassport passport, Status statusTag, Object[] o)
     {
         throw new UnsupportedOperationException("Unexpected HBCI callback");
     }

--- a/src/main/java/org/kapott/hbci/comm/Comm.java
+++ b/src/main/java/org/kapott/hbci/comm/Comm.java
@@ -69,14 +69,14 @@ public abstract class Comm
         MsgGen       gen=handler.getMsgGen();
         
         // ausgehende nachricht versenden
-        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.STATUS_MSG_SEND,null);
-        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.STATUS_MSG_RAW_SEND,msg.toString(0));
+        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.MSG_SEND,null);
+        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.MSG_RAW_SEND,msg.toString(0));
         ping(msg);
 
         // nachricht empfangen
-        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.STATUS_MSG_RECV,null);
+        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.MSG_RECV,null);
         String st = pong(gen).toString();
-        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.STATUS_MSG_RAW_RECV_ENCRYPTED,st);
+        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.MSG_RAW_RECV_ENCRYPTED,st);
 
         HBCIUtils.log("received message: "+st,HBCIUtils.LOG_DEBUG2);
         MSG retmsg=null;
@@ -104,7 +104,7 @@ public abstract class Comm
             }
             
             // versuche, nachricht als verschlüsselte nachricht zu parsen
-            HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.STATUS_MSG_PARSE,"CryptedRes");
+            HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.MSG_PARSE,"CryptedRes");
             try {
                 HBCIUtils.log("trying to parse message as crypted message",HBCIUtils.LOG_DEBUG);
                 retmsg = MSGFactory.getInstance().createMSG("CryptedRes",st,st.length(),gen,MSG.DONT_CHECK_SEQ);
@@ -119,7 +119,7 @@ public abstract class Comm
                 }
                 
                 // versuch, nachricht als unverschlüsselte msg zu parsen
-                HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.STATUS_MSG_PARSE,msgName+"Res");
+                HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.MSG_PARSE,msgName+"Res");
                 retmsg = MSGFactory.getInstance().createMSG(msgName+"Res",st,st.length(),gen);
             }
         } catch (Exception ex) {

--- a/src/main/java/org/kapott/hbci/comm/Comm.java
+++ b/src/main/java/org/kapott/hbci/comm/Comm.java
@@ -58,7 +58,7 @@ public abstract class Comm
         this.parentPassport=parentPassport;
         this.filter=parentPassport.getCommFilter();
         
-        HBCIUtilsInternal.getCallback().callback(parentPassport,HBCICallback.NEED_CONNECTION,
+        HBCIUtilsInternal.getCallback().callback(parentPassport,HBCICallback.Reason.NEED_CONNECTION,
                 HBCIUtilsInternal.getLocMsg("CALLB_NEED_CONN"),ResponseType.NONE,new StringBuffer());
     }
 
@@ -147,7 +147,7 @@ public abstract class Comm
     public void close()
     {
         closeConnection();
-        HBCIUtilsInternal.getCallback().callback(getParentPassport(),HBCICallback.CLOSE_CONNECTION,
+        HBCIUtilsInternal.getCallback().callback(getParentPassport(),HBCICallback.Reason.CLOSE_CONNECTION,
                 HBCIUtilsInternal.getLocMsg("CALLB_CLOSE_CONN"),ResponseType.NONE,new StringBuffer());
     }
 }

--- a/src/main/java/org/kapott/hbci/comm/Comm.java
+++ b/src/main/java/org/kapott/hbci/comm/Comm.java
@@ -69,14 +69,14 @@ public abstract class Comm
         MsgGen       gen=handler.getMsgGen();
         
         // ausgehende nachricht versenden
-        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.STATUS_MSG_SEND,null);
-        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.STATUS_MSG_RAW_SEND,msg.toString(0));
+        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.STATUS_MSG_SEND,null);
+        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.STATUS_MSG_RAW_SEND,msg.toString(0));
         ping(msg);
 
         // nachricht empfangen
-        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.STATUS_MSG_RECV,null);
+        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.STATUS_MSG_RECV,null);
         String st = pong(gen).toString();
-        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.STATUS_MSG_RAW_RECV_ENCRYPTED,st);
+        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.STATUS_MSG_RAW_RECV_ENCRYPTED,st);
 
         HBCIUtils.log("received message: "+st,HBCIUtils.LOG_DEBUG2);
         MSG retmsg=null;
@@ -104,7 +104,7 @@ public abstract class Comm
             }
             
             // versuche, nachricht als verschlüsselte nachricht zu parsen
-            HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.STATUS_MSG_PARSE,"CryptedRes");
+            HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.STATUS_MSG_PARSE,"CryptedRes");
             try {
                 HBCIUtils.log("trying to parse message as crypted message",HBCIUtils.LOG_DEBUG);
                 retmsg = MSGFactory.getInstance().createMSG("CryptedRes",st,st.length(),gen,MSG.DONT_CHECK_SEQ);
@@ -119,7 +119,7 @@ public abstract class Comm
                 }
                 
                 // versuch, nachricht als unverschlüsselte msg zu parsen
-                HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.STATUS_MSG_PARSE,msgName+"Res");
+                HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.STATUS_MSG_PARSE,msgName+"Res");
                 retmsg = MSGFactory.getInstance().createMSG(msgName+"Res",st,st.length(),gen);
             }
         } catch (Exception ex) {

--- a/src/main/java/org/kapott/hbci/comm/Comm.java
+++ b/src/main/java/org/kapott/hbci/comm/Comm.java
@@ -58,7 +58,7 @@ public abstract class Comm
         this.filter=parentPassport.getCommFilter();
         
         HBCIUtilsInternal.getCallback().callback(parentPassport,HBCICallback.NEED_CONNECTION,
-                HBCIUtilsInternal.getLocMsg("CALLB_NEED_CONN"),HBCICallback.ResponseType.TYPE_NONE,new StringBuffer());
+                HBCIUtilsInternal.getLocMsg("CALLB_NEED_CONN"),HBCICallback.ResponseType.NONE,new StringBuffer());
     }
 
     public MSG pingpong(String msgName, MSG msg)
@@ -147,6 +147,6 @@ public abstract class Comm
     {
         closeConnection();
         HBCIUtilsInternal.getCallback().callback(getParentPassport(),HBCICallback.CLOSE_CONNECTION,
-                HBCIUtilsInternal.getLocMsg("CALLB_CLOSE_CONN"),HBCICallback.ResponseType.TYPE_NONE,new StringBuffer());
+                HBCIUtilsInternal.getLocMsg("CALLB_CLOSE_CONN"),HBCICallback.ResponseType.NONE,new StringBuffer());
     }
 }

--- a/src/main/java/org/kapott/hbci/comm/Comm.java
+++ b/src/main/java/org/kapott/hbci/comm/Comm.java
@@ -25,9 +25,9 @@ import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.StringTokenizer;
 
-import org.kapott.hbci.callback.HBCICallback;
 import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
+import org.kapott.hbci.callback.HBCICallback.Status;
 import org.kapott.hbci.exceptions.CanNotParseMessageException;
 import org.kapott.hbci.exceptions.HBCI_Exception;
 import org.kapott.hbci.exceptions.ParseErrorException;
@@ -69,14 +69,14 @@ public abstract class Comm
         MsgGen       gen=handler.getMsgGen();
         
         // ausgehende nachricht versenden
-        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.MSG_SEND,null);
-        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.MSG_RAW_SEND,msg.toString(0));
+        HBCIUtilsInternal.getCallback().status(getParentPassport(),Status.MSG_SEND,null);
+        HBCIUtilsInternal.getCallback().status(getParentPassport(),Status.MSG_RAW_SEND,msg.toString(0));
         ping(msg);
 
         // nachricht empfangen
-        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.MSG_RECV,null);
+        HBCIUtilsInternal.getCallback().status(getParentPassport(),Status.MSG_RECV,null);
         String st = pong(gen).toString();
-        HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.MSG_RAW_RECV_ENCRYPTED,st);
+        HBCIUtilsInternal.getCallback().status(getParentPassport(),Status.MSG_RAW_RECV_ENCRYPTED,st);
 
         HBCIUtils.log("received message: "+st,HBCIUtils.LOG_DEBUG2);
         MSG retmsg=null;
@@ -104,7 +104,7 @@ public abstract class Comm
             }
             
             // versuche, nachricht als verschlüsselte nachricht zu parsen
-            HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.MSG_PARSE,"CryptedRes");
+            HBCIUtilsInternal.getCallback().status(getParentPassport(),Status.MSG_PARSE,"CryptedRes");
             try {
                 HBCIUtils.log("trying to parse message as crypted message",HBCIUtils.LOG_DEBUG);
                 retmsg = MSGFactory.getInstance().createMSG("CryptedRes",st,st.length(),gen,MSG.DONT_CHECK_SEQ);
@@ -119,7 +119,7 @@ public abstract class Comm
                 }
                 
                 // versuch, nachricht als unverschlüsselte msg zu parsen
-                HBCIUtilsInternal.getCallback().status(getParentPassport(),HBCICallback.Status.MSG_PARSE,msgName+"Res");
+                HBCIUtilsInternal.getCallback().status(getParentPassport(),Status.MSG_PARSE,msgName+"Res");
                 retmsg = MSGFactory.getInstance().createMSG(msgName+"Res",st,st.length(),gen);
             }
         } catch (Exception ex) {

--- a/src/main/java/org/kapott/hbci/comm/Comm.java
+++ b/src/main/java/org/kapott/hbci/comm/Comm.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.StringTokenizer;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.exceptions.CanNotParseMessageException;
 import org.kapott.hbci.exceptions.HBCI_Exception;
 import org.kapott.hbci.exceptions.ParseErrorException;
@@ -58,7 +59,7 @@ public abstract class Comm
         this.filter=parentPassport.getCommFilter();
         
         HBCIUtilsInternal.getCallback().callback(parentPassport,HBCICallback.NEED_CONNECTION,
-                HBCIUtilsInternal.getLocMsg("CALLB_NEED_CONN"),HBCICallback.ResponseType.NONE,new StringBuffer());
+                HBCIUtilsInternal.getLocMsg("CALLB_NEED_CONN"),ResponseType.NONE,new StringBuffer());
     }
 
     public MSG pingpong(String msgName, MSG msg)
@@ -147,6 +148,6 @@ public abstract class Comm
     {
         closeConnection();
         HBCIUtilsInternal.getCallback().callback(getParentPassport(),HBCICallback.CLOSE_CONNECTION,
-                HBCIUtilsInternal.getLocMsg("CALLB_CLOSE_CONN"),HBCICallback.ResponseType.NONE,new StringBuffer());
+                HBCIUtilsInternal.getLocMsg("CALLB_CLOSE_CONN"),ResponseType.NONE,new StringBuffer());
     }
 }

--- a/src/main/java/org/kapott/hbci/comm/Comm.java
+++ b/src/main/java/org/kapott/hbci/comm/Comm.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.StringTokenizer;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.exceptions.CanNotParseMessageException;
 import org.kapott.hbci.exceptions.HBCI_Exception;
@@ -58,7 +59,7 @@ public abstract class Comm
         this.parentPassport=parentPassport;
         this.filter=parentPassport.getCommFilter();
         
-        HBCIUtilsInternal.getCallback().callback(parentPassport,HBCICallback.Reason.NEED_CONNECTION,
+        HBCIUtilsInternal.getCallback().callback(parentPassport,Reason.NEED_CONNECTION,
                 HBCIUtilsInternal.getLocMsg("CALLB_NEED_CONN"),ResponseType.NONE,new StringBuffer());
     }
 
@@ -147,7 +148,7 @@ public abstract class Comm
     public void close()
     {
         closeConnection();
-        HBCIUtilsInternal.getCallback().callback(getParentPassport(),HBCICallback.Reason.CLOSE_CONNECTION,
+        HBCIUtilsInternal.getCallback().callback(getParentPassport(),Reason.CLOSE_CONNECTION,
                 HBCIUtilsInternal.getLocMsg("CALLB_CLOSE_CONN"),ResponseType.NONE,new StringBuffer());
     }
 }

--- a/src/main/java/org/kapott/hbci/comm/Comm.java
+++ b/src/main/java/org/kapott/hbci/comm/Comm.java
@@ -58,7 +58,7 @@ public abstract class Comm
         this.filter=parentPassport.getCommFilter();
         
         HBCIUtilsInternal.getCallback().callback(parentPassport,HBCICallback.NEED_CONNECTION,
-                HBCIUtilsInternal.getLocMsg("CALLB_NEED_CONN"),HBCICallback.TYPE_NONE,new StringBuffer());
+                HBCIUtilsInternal.getLocMsg("CALLB_NEED_CONN"),HBCICallback.ResponseType.TYPE_NONE,new StringBuffer());
     }
 
     public MSG pingpong(String msgName, MSG msg)
@@ -147,6 +147,6 @@ public abstract class Comm
     {
         closeConnection();
         HBCIUtilsInternal.getCallback().callback(getParentPassport(),HBCICallback.CLOSE_CONNECTION,
-                HBCIUtilsInternal.getLocMsg("CALLB_CLOSE_CONN"),HBCICallback.TYPE_NONE,new StringBuffer());
+                HBCIUtilsInternal.getLocMsg("CALLB_CLOSE_CONN"),HBCICallback.ResponseType.TYPE_NONE,new StringBuffer());
     }
 }

--- a/src/main/java/org/kapott/hbci/comm/PinTanProxyAuthenticator.java
+++ b/src/main/java/org/kapott/hbci/comm/PinTanProxyAuthenticator.java
@@ -54,7 +54,7 @@ extends Authenticator
             StringBuffer retData=new StringBuffer();
             callback.callback(
                     passport,
-                    HBCICallback.NEED_PROXY_USER,
+                    HBCICallback.Reason.NEED_PROXY_USER,
                     HBCIUtilsInternal.getLocMsg("CALLB_PROXY_USERNAME"),
                     ResponseType.TEXT,
                     retData);
@@ -68,7 +68,7 @@ extends Authenticator
             StringBuffer retData=new StringBuffer();
             callback.callback(
                     passport,
-                    HBCICallback.NEED_PROXY_PASS,
+                    HBCICallback.Reason.NEED_PROXY_PASS,
                     HBCIUtilsInternal.getLocMsg("CALLB_PROXY_PASSWD"),
                     ResponseType.SECRET,
                     retData);

--- a/src/main/java/org/kapott/hbci/comm/PinTanProxyAuthenticator.java
+++ b/src/main/java/org/kapott/hbci/comm/PinTanProxyAuthenticator.java
@@ -55,7 +55,7 @@ extends Authenticator
                     passport,
                     HBCICallback.NEED_PROXY_USER,
                     HBCIUtilsInternal.getLocMsg("CALLB_PROXY_USERNAME"),
-                    HBCICallback.TYPE_TEXT,
+                    HBCICallback.ResponseType.TYPE_TEXT,
                     retData);
             user=retData.toString();
             LogFilter.getInstance().addSecretData(user,"X",LogFilter.FILTER_IDS);
@@ -69,7 +69,7 @@ extends Authenticator
                     passport,
                     HBCICallback.NEED_PROXY_PASS,
                     HBCIUtilsInternal.getLocMsg("CALLB_PROXY_PASSWD"),
-                    HBCICallback.TYPE_SECRET,
+                    HBCICallback.ResponseType.TYPE_SECRET,
                     retData);
             pass=retData.toString();
             LogFilter.getInstance().addSecretData(pass,"X",LogFilter.FILTER_SECRETS);

--- a/src/main/java/org/kapott/hbci/comm/PinTanProxyAuthenticator.java
+++ b/src/main/java/org/kapott/hbci/comm/PinTanProxyAuthenticator.java
@@ -55,7 +55,7 @@ extends Authenticator
                     passport,
                     HBCICallback.NEED_PROXY_USER,
                     HBCIUtilsInternal.getLocMsg("CALLB_PROXY_USERNAME"),
-                    HBCICallback.ResponseType.TYPE_TEXT,
+                    HBCICallback.ResponseType.TEXT,
                     retData);
             user=retData.toString();
             LogFilter.getInstance().addSecretData(user,"X",LogFilter.FILTER_IDS);
@@ -69,7 +69,7 @@ extends Authenticator
                     passport,
                     HBCICallback.NEED_PROXY_PASS,
                     HBCIUtilsInternal.getLocMsg("CALLB_PROXY_PASSWD"),
-                    HBCICallback.ResponseType.TYPE_SECRET,
+                    HBCICallback.ResponseType.SECRET,
                     retData);
             pass=retData.toString();
             LogFilter.getInstance().addSecretData(pass,"X",LogFilter.FILTER_SECRETS);

--- a/src/main/java/org/kapott/hbci/comm/PinTanProxyAuthenticator.java
+++ b/src/main/java/org/kapott/hbci/comm/PinTanProxyAuthenticator.java
@@ -25,6 +25,7 @@ import java.net.Authenticator;
 import java.net.PasswordAuthentication;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.manager.HBCIUtils;
 import org.kapott.hbci.manager.HBCIUtilsInternal;
 import org.kapott.hbci.manager.LogFilter;
@@ -55,7 +56,7 @@ extends Authenticator
                     passport,
                     HBCICallback.NEED_PROXY_USER,
                     HBCIUtilsInternal.getLocMsg("CALLB_PROXY_USERNAME"),
-                    HBCICallback.ResponseType.TEXT,
+                    ResponseType.TEXT,
                     retData);
             user=retData.toString();
             LogFilter.getInstance().addSecretData(user,"X",LogFilter.FILTER_IDS);
@@ -69,7 +70,7 @@ extends Authenticator
                     passport,
                     HBCICallback.NEED_PROXY_PASS,
                     HBCIUtilsInternal.getLocMsg("CALLB_PROXY_PASSWD"),
-                    HBCICallback.ResponseType.SECRET,
+                    ResponseType.SECRET,
                     retData);
             pass=retData.toString();
             LogFilter.getInstance().addSecretData(pass,"X",LogFilter.FILTER_SECRETS);

--- a/src/main/java/org/kapott/hbci/comm/PinTanProxyAuthenticator.java
+++ b/src/main/java/org/kapott/hbci/comm/PinTanProxyAuthenticator.java
@@ -25,6 +25,7 @@ import java.net.Authenticator;
 import java.net.PasswordAuthentication;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.manager.HBCIUtils;
 import org.kapott.hbci.manager.HBCIUtilsInternal;
@@ -54,7 +55,7 @@ extends Authenticator
             StringBuffer retData=new StringBuffer();
             callback.callback(
                     passport,
-                    HBCICallback.Reason.NEED_PROXY_USER,
+                    Reason.NEED_PROXY_USER,
                     HBCIUtilsInternal.getLocMsg("CALLB_PROXY_USERNAME"),
                     ResponseType.TEXT,
                     retData);
@@ -68,7 +69,7 @@ extends Authenticator
             StringBuffer retData=new StringBuffer();
             callback.callback(
                     passport,
-                    HBCICallback.Reason.NEED_PROXY_PASS,
+                    Reason.NEED_PROXY_PASS,
                     HBCIUtilsInternal.getLocMsg("CALLB_PROXY_PASSWD"),
                     ResponseType.SECRET,
                     retData);

--- a/src/main/java/org/kapott/hbci/dialog/HBCIDialogEnd.java
+++ b/src/main/java/org/kapott/hbci/dialog/HBCIDialogEnd.java
@@ -105,7 +105,7 @@ public class HBCIDialogEnd extends AbstractRawHBCIDialog
 
         final HBCIMsgStatus ret = ctx.getMsgStatus();
         
-        HBCIUtilsInternal.getCallback().status(ctx.getPassport(),HBCICallback.STATUS_DIALOG_END_DONE,ret);
+        HBCIUtilsInternal.getCallback().status(ctx.getPassport(),HBCICallback.Status.STATUS_DIALOG_END_DONE,ret);
 
         if (ret.isOK())
             return;

--- a/src/main/java/org/kapott/hbci/dialog/HBCIDialogEnd.java
+++ b/src/main/java/org/kapott/hbci/dialog/HBCIDialogEnd.java
@@ -105,7 +105,7 @@ public class HBCIDialogEnd extends AbstractRawHBCIDialog
 
         final HBCIMsgStatus ret = ctx.getMsgStatus();
         
-        HBCIUtilsInternal.getCallback().status(ctx.getPassport(),HBCICallback.Status.STATUS_DIALOG_END_DONE,ret);
+        HBCIUtilsInternal.getCallback().status(ctx.getPassport(),HBCICallback.Status.DIALOG_END_DONE,ret);
 
         if (ret.isOK())
             return;

--- a/src/main/java/org/kapott/hbci/dialog/HBCIDialogEnd.java
+++ b/src/main/java/org/kapott/hbci/dialog/HBCIDialogEnd.java
@@ -25,7 +25,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.Status;
 import org.kapott.hbci.exceptions.ProcessException;
 import org.kapott.hbci.manager.HBCIKernelImpl;
 import org.kapott.hbci.manager.HBCIUtils;
@@ -105,7 +105,7 @@ public class HBCIDialogEnd extends AbstractRawHBCIDialog
 
         final HBCIMsgStatus ret = ctx.getMsgStatus();
         
-        HBCIUtilsInternal.getCallback().status(ctx.getPassport(),HBCICallback.Status.DIALOG_END_DONE,ret);
+        HBCIUtilsInternal.getCallback().status(ctx.getPassport(),Status.DIALOG_END_DONE,ret);
 
         if (ret.isOK())
             return;

--- a/src/main/java/org/kapott/hbci/examples/UmsatzAbrufPinTan.java
+++ b/src/main/java/org/kapott/hbci/examples/UmsatzAbrufPinTan.java
@@ -398,11 +398,8 @@ public class UmsatzAbrufPinTan
       }
     }
 
-    /**
-     * @see org.kapott.hbci.callback.HBCICallback#status(org.kapott.hbci.passport.HBCIPassport, int, java.lang.Object[])
-     */
     @Override
-    public void status(HBCIPassport passport, int statusTag, Object[] o)
+    public void status(HBCIPassport passport, Status statusTag, Object[] o)
     {
       // So aehnlich wie log(String,int,Date,StackTraceElement) jedoch fuer Status-Meldungen.
     }

--- a/src/main/java/org/kapott/hbci/examples/UmsatzAbrufPinTan.java
+++ b/src/main/java/org/kapott/hbci/examples/UmsatzAbrufPinTan.java
@@ -204,10 +204,10 @@ public class UmsatzAbrufPinTan
     }
 
     /**
-     * @see org.kapott.hbci.callback.HBCICallback#callback(org.kapott.hbci.passport.HBCIPassport, int, java.lang.String, int, java.lang.StringBuffer)
+     * @see org.kapott.hbci.callback.HBCICallback#callback(org.kapott.hbci.passport.HBCIPassport, int, java.lang.String, ResponseType, java.lang.StringBuffer)
      */
     @Override
-    public void callback(HBCIPassport passport, int reason, String msg, int datatype, StringBuffer retData)
+    public void callback(HBCIPassport passport, int reason, String msg, ResponseType datatype, StringBuffer retData)
     {
       // Diese Funktion ist wichtig. Ueber die fragt HBCI4Java die benoetigten Daten von uns ab.
       switch (reason)

--- a/src/main/java/org/kapott/hbci/examples/UmsatzAbrufPinTan.java
+++ b/src/main/java/org/kapott/hbci/examples/UmsatzAbrufPinTan.java
@@ -204,10 +204,10 @@ public class UmsatzAbrufPinTan
     }
 
     /**
-     * @see org.kapott.hbci.callback.HBCICallback#callback(org.kapott.hbci.passport.HBCIPassport, int, java.lang.String, ResponseType, java.lang.StringBuffer)
+     * @see org.kapott.hbci.callback.HBCICallback#callback(org.kapott.hbci.passport.HBCIPassport, Reason, java.lang.String, ResponseType, java.lang.StringBuffer)
      */
     @Override
-    public void callback(HBCIPassport passport, int reason, String msg, ResponseType datatype, StringBuffer retData)
+    public void callback(HBCIPassport passport, Reason reason, String msg, ResponseType datatype, StringBuffer retData)
     {
       // Diese Funktion ist wichtig. Ueber die fragt HBCI4Java die benoetigten Daten von uns ab.
       switch (reason)

--- a/src/main/java/org/kapott/hbci/examples/UmsatzAbrufPinTan.java
+++ b/src/main/java/org/kapott/hbci/examples/UmsatzAbrufPinTan.java
@@ -193,9 +193,6 @@ public class UmsatzAbrufPinTan
    */
   private static class MyHBCICallback extends AbstractHBCICallback
   {
-    /**
-     * @see org.kapott.hbci.callback.HBCICallback#log(java.lang.String, int, java.util.Date, java.lang.StackTraceElement)
-     */
     @Override
     public void log(String msg, int level, Date date, StackTraceElement trace)
     {
@@ -203,9 +200,6 @@ public class UmsatzAbrufPinTan
       // System.out.println(msg);
     }
 
-    /**
-     * @see org.kapott.hbci.callback.HBCICallback#callback(org.kapott.hbci.passport.HBCIPassport, Reason, java.lang.String, ResponseType, java.lang.StringBuffer)
-     */
     @Override
     public void callback(HBCIPassport passport, Reason reason, String msg, ResponseType datatype, StringBuffer retData)
     {

--- a/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
@@ -145,7 +145,7 @@ public final class HBCIDialog
                     HBCIUtilsInternal.getCallback().callback(mainPassport,
                                                      HBCICallback.HAVE_INST_MSG,
                                                      msg.toString(),
-                                                     HBCICallback.TYPE_NONE,
+                                                     HBCICallback.ResponseType.TYPE_NONE,
                                                      new StringBuffer());
                 }
             }

--- a/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
@@ -106,7 +106,7 @@ public final class HBCIDialog
             HBCIUtils.log("passport supported: "+s,HBCIUtils.LOG_DEBUG);
             
             HBCIUtils.log(HBCIUtilsInternal.getLocMsg("STATUS_DIALOG_INIT"),HBCIUtils.LOG_INFO);
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.STATUS_DIALOG_INIT,null);
+            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_DIALOG_INIT,null);
     
             // Dialog-Context erzeugen
             final DialogContext ctx = DialogContext.create(kernel,mainPassport);
@@ -152,7 +152,7 @@ public final class HBCIDialog
                 }
             }
 
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.STATUS_DIALOG_INIT_DONE,new Object[] {ret,dialogid});
+            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_DIALOG_INIT_DONE,new Object[] {ret,dialogid});
         }
         catch (Exception e)
         {
@@ -234,7 +234,7 @@ public final class HBCIDialog
                     }
                     
                     HBCIUtils.log("adding task " + name,HBCIUtils.LOG_DEBUG);
-                    HBCIUtilsInternal.getCallback().status(p,HBCICallback.STATUS_SEND_TASK,task);
+                    HBCIUtilsInternal.getCallback().status(p,HBCICallback.Status.STATUS_SEND_TASK,task);
 
                     // Uebernimmt den aktuellen loop-Wert in die Lowlevel-Parameter
                     task.applyOffset();
@@ -294,7 +294,7 @@ public final class HBCIDialog
                         {
                             HBCIUtils.log("filling results for task " + name, HBCIUtils.LOG_DEBUG);
                             task.fillJobResult(msgstatus,segnum);
-                            HBCIUtilsInternal.getCallback().status(p,HBCICallback.STATUS_SEND_TASK_DONE,task);
+                            HBCIUtilsInternal.getCallback().status(p,HBCICallback.Status.STATUS_SEND_TASK_DONE,task);
                         }
                         catch (Exception e)
                         {
@@ -412,7 +412,7 @@ public final class HBCIDialog
         
         try {
             HBCIUtils.log(HBCIUtilsInternal.getLocMsg("LOG_DIALOG_END"),HBCIUtils.LOG_INFO);
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.STATUS_DIALOG_END,null);
+            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_DIALOG_END,null);
     
             kernel.rawNewMsg("DialogEnd"+anonSuffix);
             kernel.rawSet("DialogEndS.dialogid", dialogid);
@@ -424,7 +424,7 @@ public final class HBCIDialog
                                !isAnon && HBCIKernelImpl.CRYPTIT,
                                !isAnon && HBCIKernelImpl.NEED_CRYPT);
 
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.STATUS_DIALOG_END_DONE,ret);
+            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_DIALOG_END_DONE,ret);
         } catch (Exception e) {
             ret.addException(e);
         }

--- a/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
@@ -106,7 +106,7 @@ public final class HBCIDialog
             HBCIUtils.log("passport supported: "+s,HBCIUtils.LOG_DEBUG);
             
             HBCIUtils.log(HBCIUtilsInternal.getLocMsg("STATUS_DIALOG_INIT"),HBCIUtils.LOG_INFO);
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_DIALOG_INIT,null);
+            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.DIALOG_INIT,null);
     
             // Dialog-Context erzeugen
             final DialogContext ctx = DialogContext.create(kernel,mainPassport);
@@ -152,7 +152,7 @@ public final class HBCIDialog
                 }
             }
 
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_DIALOG_INIT_DONE,new Object[] {ret,dialogid});
+            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.DIALOG_INIT_DONE,new Object[] {ret,dialogid});
         }
         catch (Exception e)
         {
@@ -234,7 +234,7 @@ public final class HBCIDialog
                     }
                     
                     HBCIUtils.log("adding task " + name,HBCIUtils.LOG_DEBUG);
-                    HBCIUtilsInternal.getCallback().status(p,HBCICallback.Status.STATUS_SEND_TASK,task);
+                    HBCIUtilsInternal.getCallback().status(p,HBCICallback.Status.SEND_TASK,task);
 
                     // Uebernimmt den aktuellen loop-Wert in die Lowlevel-Parameter
                     task.applyOffset();
@@ -294,7 +294,7 @@ public final class HBCIDialog
                         {
                             HBCIUtils.log("filling results for task " + name, HBCIUtils.LOG_DEBUG);
                             task.fillJobResult(msgstatus,segnum);
-                            HBCIUtilsInternal.getCallback().status(p,HBCICallback.Status.STATUS_SEND_TASK_DONE,task);
+                            HBCIUtilsInternal.getCallback().status(p,HBCICallback.Status.SEND_TASK_DONE,task);
                         }
                         catch (Exception e)
                         {
@@ -412,7 +412,7 @@ public final class HBCIDialog
         
         try {
             HBCIUtils.log(HBCIUtilsInternal.getLocMsg("LOG_DIALOG_END"),HBCIUtils.LOG_INFO);
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_DIALOG_END,null);
+            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.DIALOG_END,null);
     
             kernel.rawNewMsg("DialogEnd"+anonSuffix);
             kernel.rawSet("DialogEndS.dialogid", dialogid);
@@ -424,7 +424,7 @@ public final class HBCIDialog
                                !isAnon && HBCIKernelImpl.CRYPTIT,
                                !isAnon && HBCIKernelImpl.NEED_CRYPT);
 
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_DIALOG_END_DONE,ret);
+            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.DIALOG_END_DONE,ret);
         } catch (Exception e) {
             ret.addException(e);
         }

--- a/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 
 import org.kapott.hbci.GV.HBCIJobImpl;
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.dialog.DialogContext;
 import org.kapott.hbci.dialog.DialogEvent;
@@ -144,7 +145,7 @@ public final class HBCIDialog
                         break;
                     }
                     HBCIUtilsInternal.getCallback().callback(mainPassport,
-                                                     HBCICallback.Reason.HAVE_INST_MSG,
+                                                     Reason.HAVE_INST_MSG,
                                                      msg.toString(),
                                                      ResponseType.NONE,
                                                      new StringBuffer());

--- a/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
@@ -145,7 +145,7 @@ public final class HBCIDialog
                     HBCIUtilsInternal.getCallback().callback(mainPassport,
                                                      HBCICallback.HAVE_INST_MSG,
                                                      msg.toString(),
-                                                     HBCICallback.ResponseType.TYPE_NONE,
+                                                     HBCICallback.ResponseType.NONE,
                                                      new StringBuffer());
                 }
             }

--- a/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
@@ -28,6 +28,7 @@ import java.util.Properties;
 
 import org.kapott.hbci.GV.HBCIJobImpl;
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.dialog.DialogContext;
 import org.kapott.hbci.dialog.DialogEvent;
 import org.kapott.hbci.dialog.HBCIDialogInit;
@@ -145,7 +146,7 @@ public final class HBCIDialog
                     HBCIUtilsInternal.getCallback().callback(mainPassport,
                                                      HBCICallback.HAVE_INST_MSG,
                                                      msg.toString(),
-                                                     HBCICallback.ResponseType.NONE,
+                                                     ResponseType.NONE,
                                                      new StringBuffer());
                 }
             }

--- a/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
@@ -27,9 +27,9 @@ import java.util.List;
 import java.util.Properties;
 
 import org.kapott.hbci.GV.HBCIJobImpl;
-import org.kapott.hbci.callback.HBCICallback;
 import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
+import org.kapott.hbci.callback.HBCICallback.Status;
 import org.kapott.hbci.dialog.DialogContext;
 import org.kapott.hbci.dialog.DialogEvent;
 import org.kapott.hbci.dialog.HBCIDialogInit;
@@ -106,7 +106,7 @@ public final class HBCIDialog
             HBCIUtils.log("passport supported: "+s,HBCIUtils.LOG_DEBUG);
             
             HBCIUtils.log(HBCIUtilsInternal.getLocMsg("STATUS_DIALOG_INIT"),HBCIUtils.LOG_INFO);
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.DIALOG_INIT,null);
+            HBCIUtilsInternal.getCallback().status(mainPassport,Status.DIALOG_INIT,null);
     
             // Dialog-Context erzeugen
             final DialogContext ctx = DialogContext.create(kernel,mainPassport);
@@ -152,7 +152,7 @@ public final class HBCIDialog
                 }
             }
 
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.DIALOG_INIT_DONE,new Object[] {ret,dialogid});
+            HBCIUtilsInternal.getCallback().status(mainPassport,Status.DIALOG_INIT_DONE,new Object[] {ret,dialogid});
         }
         catch (Exception e)
         {
@@ -234,7 +234,7 @@ public final class HBCIDialog
                     }
                     
                     HBCIUtils.log("adding task " + name,HBCIUtils.LOG_DEBUG);
-                    HBCIUtilsInternal.getCallback().status(p,HBCICallback.Status.SEND_TASK,task);
+                    HBCIUtilsInternal.getCallback().status(p,Status.SEND_TASK,task);
 
                     // Uebernimmt den aktuellen loop-Wert in die Lowlevel-Parameter
                     task.applyOffset();
@@ -294,7 +294,7 @@ public final class HBCIDialog
                         {
                             HBCIUtils.log("filling results for task " + name, HBCIUtils.LOG_DEBUG);
                             task.fillJobResult(msgstatus,segnum);
-                            HBCIUtilsInternal.getCallback().status(p,HBCICallback.Status.SEND_TASK_DONE,task);
+                            HBCIUtilsInternal.getCallback().status(p,Status.SEND_TASK_DONE,task);
                         }
                         catch (Exception e)
                         {
@@ -412,7 +412,7 @@ public final class HBCIDialog
         
         try {
             HBCIUtils.log(HBCIUtilsInternal.getLocMsg("LOG_DIALOG_END"),HBCIUtils.LOG_INFO);
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.DIALOG_END,null);
+            HBCIUtilsInternal.getCallback().status(mainPassport,Status.DIALOG_END,null);
     
             kernel.rawNewMsg("DialogEnd"+anonSuffix);
             kernel.rawSet("DialogEndS.dialogid", dialogid);
@@ -424,7 +424,7 @@ public final class HBCIDialog
                                !isAnon && HBCIKernelImpl.CRYPTIT,
                                !isAnon && HBCIKernelImpl.NEED_CRYPT);
 
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.DIALOG_END_DONE,ret);
+            HBCIUtilsInternal.getCallback().status(mainPassport,Status.DIALOG_END_DONE,ret);
         } catch (Exception e) {
             ret.addException(e);
         }

--- a/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
@@ -144,7 +144,7 @@ public final class HBCIDialog
                         break;
                     }
                     HBCIUtilsInternal.getCallback().callback(mainPassport,
-                                                     HBCICallback.HAVE_INST_MSG,
+                                                     HBCICallback.Reason.HAVE_INST_MSG,
                                                      msg.toString(),
                                                      ResponseType.NONE,
                                                      new StringBuffer());

--- a/src/main/java/org/kapott/hbci/manager/HBCIInstitute.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIInstitute.java
@@ -95,7 +95,7 @@ public final class HBCIInstitute
             p.setProperty(BPD_KEY_LASTUPDATE,String.valueOf(System.currentTimeMillis()));
             passport.setBPD(p);
             HBCIUtils.log("installed new BPD with version "+passport.getBPDVersion(),HBCIUtils.LOG_DEBUG);
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_INST_BPD_INIT_DONE,passport.getBPD());
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INST_BPD_INIT_DONE,passport.getBPD());
         }
     }
 
@@ -149,7 +149,7 @@ public final class HBCIInstitute
         }
         
         if (foundChanges) {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_INST_GET_KEYS_DONE,null);
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INST_GET_KEYS_DONE,null);
             acknowledgeNewKeys();
         }
     }
@@ -265,7 +265,7 @@ public final class HBCIInstitute
                     passport.saveChanges();
                 }
                 
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_INST_BPD_INIT,null);
+                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INST_BPD_INIT,null);
                 HBCIUtils.log("Aktualisiere Bankparameter (BPD)",HBCIUtils.LOG_INFO);
                 
                 // Dialog-Context erzeugen
@@ -339,7 +339,7 @@ public final class HBCIInstitute
         // *immer* true zurückgibt
             
         try {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_INST_GET_KEYS,null);
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INST_GET_KEYS,null);
             HBCIUtils.log("Rufe Institutsschlüssel ab",HBCIUtils.LOG_INFO);
             
             // Dialog-Context erzeugen

--- a/src/main/java/org/kapott/hbci/manager/HBCIInstitute.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIInstitute.java
@@ -159,7 +159,7 @@ public final class HBCIInstitute
         HBCIUtilsInternal.getCallback().callback(passport,
                                          HBCICallback.NEED_NEW_INST_KEYS_ACK,
                                          HBCIUtilsInternal.getLocMsg("CALLB_NEW_INST_KEYS"),
-                                         HBCICallback.ResponseType.TYPE_BOOLEAN,
+                                         HBCICallback.ResponseType.BOOLEAN,
                                          answer);
 
         if (answer.length()>0) {

--- a/src/main/java/org/kapott/hbci/manager/HBCIInstitute.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIInstitute.java
@@ -95,7 +95,7 @@ public final class HBCIInstitute
             p.setProperty(BPD_KEY_LASTUPDATE,String.valueOf(System.currentTimeMillis()));
             passport.setBPD(p);
             HBCIUtils.log("installed new BPD with version "+passport.getBPDVersion(),HBCIUtils.LOG_DEBUG);
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INST_BPD_INIT_DONE,passport.getBPD());
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INST_BPD_INIT_DONE,passport.getBPD());
         }
     }
 
@@ -149,7 +149,7 @@ public final class HBCIInstitute
         }
         
         if (foundChanges) {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INST_GET_KEYS_DONE,null);
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INST_GET_KEYS_DONE,null);
             acknowledgeNewKeys();
         }
     }
@@ -265,7 +265,7 @@ public final class HBCIInstitute
                     passport.saveChanges();
                 }
                 
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INST_BPD_INIT,null);
+                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INST_BPD_INIT,null);
                 HBCIUtils.log("Aktualisiere Bankparameter (BPD)",HBCIUtils.LOG_INFO);
                 
                 // Dialog-Context erzeugen
@@ -339,7 +339,7 @@ public final class HBCIInstitute
         // *immer* true zurückgibt
             
         try {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INST_GET_KEYS,null);
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INST_GET_KEYS,null);
             HBCIUtils.log("Rufe Institutsschlüssel ab",HBCIUtils.LOG_INFO);
             
             // Dialog-Context erzeugen

--- a/src/main/java/org/kapott/hbci/manager/HBCIInstitute.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIInstitute.java
@@ -32,6 +32,7 @@ import java.util.Enumeration;
 import java.util.Properties;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.comm.Comm;
 import org.kapott.hbci.dialog.DialogContext;
 import org.kapott.hbci.dialog.HBCIDialogEnd;
@@ -159,7 +160,7 @@ public final class HBCIInstitute
         HBCIUtilsInternal.getCallback().callback(passport,
                                          HBCICallback.NEED_NEW_INST_KEYS_ACK,
                                          HBCIUtilsInternal.getLocMsg("CALLB_NEW_INST_KEYS"),
-                                         HBCICallback.ResponseType.BOOLEAN,
+                                         ResponseType.BOOLEAN,
                                          answer);
 
         if (answer.length()>0) {

--- a/src/main/java/org/kapott/hbci/manager/HBCIInstitute.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIInstitute.java
@@ -33,6 +33,7 @@ import java.util.Properties;
 
 import org.kapott.hbci.callback.HBCICallback;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
+import org.kapott.hbci.callback.HBCICallback.Status;
 import org.kapott.hbci.comm.Comm;
 import org.kapott.hbci.dialog.DialogContext;
 import org.kapott.hbci.dialog.HBCIDialogEnd;
@@ -95,7 +96,7 @@ public final class HBCIInstitute
             p.setProperty(BPD_KEY_LASTUPDATE,String.valueOf(System.currentTimeMillis()));
             passport.setBPD(p);
             HBCIUtils.log("installed new BPD with version "+passport.getBPDVersion(),HBCIUtils.LOG_DEBUG);
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INST_BPD_INIT_DONE,passport.getBPD());
+            HBCIUtilsInternal.getCallback().status(passport,Status.INST_BPD_INIT_DONE,passport.getBPD());
         }
     }
 
@@ -149,7 +150,7 @@ public final class HBCIInstitute
         }
         
         if (foundChanges) {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INST_GET_KEYS_DONE,null);
+            HBCIUtilsInternal.getCallback().status(passport,Status.INST_GET_KEYS_DONE,null);
             acknowledgeNewKeys();
         }
     }
@@ -265,7 +266,7 @@ public final class HBCIInstitute
                     passport.saveChanges();
                 }
                 
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INST_BPD_INIT,null);
+                HBCIUtilsInternal.getCallback().status(passport,Status.INST_BPD_INIT,null);
                 HBCIUtils.log("Aktualisiere Bankparameter (BPD)",HBCIUtils.LOG_INFO);
                 
                 // Dialog-Context erzeugen
@@ -339,7 +340,7 @@ public final class HBCIInstitute
         // *immer* true zurückgibt
             
         try {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INST_GET_KEYS,null);
+            HBCIUtilsInternal.getCallback().status(passport,Status.INST_GET_KEYS,null);
             HBCIUtils.log("Rufe Institutsschlüssel ab",HBCIUtils.LOG_INFO);
             
             // Dialog-Context erzeugen

--- a/src/main/java/org/kapott/hbci/manager/HBCIInstitute.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIInstitute.java
@@ -158,7 +158,7 @@ public final class HBCIInstitute
     {
         StringBuffer answer=new StringBuffer();
         HBCIUtilsInternal.getCallback().callback(passport,
-                                         HBCICallback.NEED_NEW_INST_KEYS_ACK,
+                                         HBCICallback.Reason.NEED_NEW_INST_KEYS_ACK,
                                          HBCIUtilsInternal.getLocMsg("CALLB_NEW_INST_KEYS"),
                                          ResponseType.BOOLEAN,
                                          answer);

--- a/src/main/java/org/kapott/hbci/manager/HBCIInstitute.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIInstitute.java
@@ -159,7 +159,7 @@ public final class HBCIInstitute
         HBCIUtilsInternal.getCallback().callback(passport,
                                          HBCICallback.NEED_NEW_INST_KEYS_ACK,
                                          HBCIUtilsInternal.getLocMsg("CALLB_NEW_INST_KEYS"),
-                                         HBCICallback.TYPE_BOOLEAN,
+                                         HBCICallback.ResponseType.TYPE_BOOLEAN,
                                          answer);
 
         if (answer.length()>0) {

--- a/src/main/java/org/kapott/hbci/manager/HBCIKernelImpl.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIKernelImpl.java
@@ -203,7 +203,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             HBCIPassportInternal mainPassport=passports.getMainPassport();
 
             HBCIUtils.log("generating raw message "+currentMsgName,HBCIUtils.LOG_DEBUG);
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.STATUS_MSG_CREATE,currentMsgName);
+            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_MSG_CREATE,currentMsgName);
 
             // plaintextnachricht erzeugen
             msg=gen.generate(currentMsgName);
@@ -245,7 +245,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             // wenn nachricht signiert werden soll
             if (signit) {
                 HBCIUtils.log("trying to insert signature",HBCIUtils.LOG_DEBUG);
-                HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.STATUS_MSG_SIGN,null);
+                HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_MSG_SIGN,null);
                 
                 // signatur erzeugen und an nachricht anhängen
                 Sig sig=SigFactory.getInstance().createSig(getParentHandlerData(),msg,passports);
@@ -304,7 +304,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             // soll nachricht verschlüsselt werden?
             if (cryptit) {
                 HBCIUtils.log("trying to encrypt message",HBCIUtils.LOG_DEBUG);
-                HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.STATUS_MSG_CRYPT,null);
+                HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_MSG_CRYPT,null);
                 
                 // nachricht verschlüsseln
                 MSG   old=msg;
@@ -353,7 +353,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             // ist antwortnachricht verschlüsselt?
             boolean crypted=msg.getName().equals("CryptedRes");
             if (crypted) {
-                HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.STATUS_MSG_DECRYPT,null);
+                HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_MSG_DECRYPT,null);
                 
                 // wenn ja, dann nachricht entschlüsseln
                 HBCIUtils.log("acquire crypt instance",HBCIUtils.LOG_DEBUG);
@@ -363,7 +363,7 @@ public final class HBCIKernelImpl implements HBCIKernel
                     HBCIUtils.log("decrypting using " + crypt,HBCIUtils.LOG_DEBUG);
                     newmsgstring=crypt.decryptIt();
                     HBCIUtils.log("decrypted",HBCIUtils.LOG_DEBUG);
-                    HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.STATUS_MSG_RAW_RECV,newmsgstring);
+                    HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_MSG_RAW_RECV,newmsgstring);
                 } finally {
                     HBCIUtils.log("free crypt",HBCIUtils.LOG_DEBUG);
                     CryptFactory.getInstance().unuseObject(crypt);
@@ -383,7 +383,7 @@ public final class HBCIKernelImpl implements HBCIKernel
                 
                 // nachricht als plaintextnachricht parsen
                 try {
-                    HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.STATUS_MSG_PARSE,currentMsgName+"Res");
+                    HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_MSG_PARSE,currentMsgName+"Res");
                     HBCIUtils.log("message to pe parsed: "+msg.toString(0),HBCIUtils.LOG_DEBUG2);
                     MSG oldMsg=msg;
                     msg=MSGFactory.getInstance().createMSG(currentMsgName+"Res",newmsgstring,newmsgstring.length(),gen);
@@ -396,7 +396,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             }
             else
             {
-              HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.STATUS_MSG_RAW_RECV,msg.toString(0));
+              HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_MSG_RAW_RECV,msg.toString(0));
             }
             
             HBCIUtils.log("received message after decryption: "+msg.toString(0),HBCIUtils.LOG_DEBUG2);
@@ -444,7 +444,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             
             // überprüfen der signatur
             HBCIUtils.log("looking for a signature",HBCIUtils.LOG_DEBUG);
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.STATUS_MSG_VERIFY,null);
+            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_MSG_VERIFY,null);
             boolean sigOk=false;
             Sig     sig=SigFactory.getInstance().createSig(getParentHandlerData(),msg,passports);
             try {

--- a/src/main/java/org/kapott/hbci/manager/HBCIKernelImpl.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIKernelImpl.java
@@ -30,7 +30,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
-import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.Status;
 import org.kapott.hbci.exceptions.CanNotParseMessageException;
 import org.kapott.hbci.exceptions.HBCI_Exception;
 import org.kapott.hbci.exceptions.InvalidUserDataException;
@@ -203,7 +203,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             HBCIPassportInternal mainPassport=passports.getMainPassport();
 
             HBCIUtils.log("generating raw message "+currentMsgName,HBCIUtils.LOG_DEBUG);
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.MSG_CREATE,currentMsgName);
+            HBCIUtilsInternal.getCallback().status(mainPassport,Status.MSG_CREATE,currentMsgName);
 
             // plaintextnachricht erzeugen
             msg=gen.generate(currentMsgName);
@@ -245,7 +245,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             // wenn nachricht signiert werden soll
             if (signit) {
                 HBCIUtils.log("trying to insert signature",HBCIUtils.LOG_DEBUG);
-                HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.MSG_SIGN,null);
+                HBCIUtilsInternal.getCallback().status(mainPassport,Status.MSG_SIGN,null);
                 
                 // signatur erzeugen und an nachricht anhängen
                 Sig sig=SigFactory.getInstance().createSig(getParentHandlerData(),msg,passports);
@@ -304,7 +304,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             // soll nachricht verschlüsselt werden?
             if (cryptit) {
                 HBCIUtils.log("trying to encrypt message",HBCIUtils.LOG_DEBUG);
-                HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.MSG_CRYPT,null);
+                HBCIUtilsInternal.getCallback().status(mainPassport,Status.MSG_CRYPT,null);
                 
                 // nachricht verschlüsseln
                 MSG   old=msg;
@@ -353,7 +353,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             // ist antwortnachricht verschlüsselt?
             boolean crypted=msg.getName().equals("CryptedRes");
             if (crypted) {
-                HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.MSG_DECRYPT,null);
+                HBCIUtilsInternal.getCallback().status(mainPassport,Status.MSG_DECRYPT,null);
                 
                 // wenn ja, dann nachricht entschlüsseln
                 HBCIUtils.log("acquire crypt instance",HBCIUtils.LOG_DEBUG);
@@ -363,7 +363,7 @@ public final class HBCIKernelImpl implements HBCIKernel
                     HBCIUtils.log("decrypting using " + crypt,HBCIUtils.LOG_DEBUG);
                     newmsgstring=crypt.decryptIt();
                     HBCIUtils.log("decrypted",HBCIUtils.LOG_DEBUG);
-                    HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.MSG_RAW_RECV,newmsgstring);
+                    HBCIUtilsInternal.getCallback().status(mainPassport,Status.MSG_RAW_RECV,newmsgstring);
                 } finally {
                     HBCIUtils.log("free crypt",HBCIUtils.LOG_DEBUG);
                     CryptFactory.getInstance().unuseObject(crypt);
@@ -383,7 +383,7 @@ public final class HBCIKernelImpl implements HBCIKernel
                 
                 // nachricht als plaintextnachricht parsen
                 try {
-                    HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.MSG_PARSE,currentMsgName+"Res");
+                    HBCIUtilsInternal.getCallback().status(mainPassport,Status.MSG_PARSE,currentMsgName+"Res");
                     HBCIUtils.log("message to pe parsed: "+msg.toString(0),HBCIUtils.LOG_DEBUG2);
                     MSG oldMsg=msg;
                     msg=MSGFactory.getInstance().createMSG(currentMsgName+"Res",newmsgstring,newmsgstring.length(),gen);
@@ -396,7 +396,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             }
             else
             {
-              HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.MSG_RAW_RECV,msg.toString(0));
+              HBCIUtilsInternal.getCallback().status(mainPassport,Status.MSG_RAW_RECV,msg.toString(0));
             }
             
             HBCIUtils.log("received message after decryption: "+msg.toString(0),HBCIUtils.LOG_DEBUG2);
@@ -444,7 +444,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             
             // überprüfen der signatur
             HBCIUtils.log("looking for a signature",HBCIUtils.LOG_DEBUG);
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.MSG_VERIFY,null);
+            HBCIUtilsInternal.getCallback().status(mainPassport,Status.MSG_VERIFY,null);
             boolean sigOk=false;
             Sig     sig=SigFactory.getInstance().createSig(getParentHandlerData(),msg,passports);
             try {

--- a/src/main/java/org/kapott/hbci/manager/HBCIKernelImpl.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIKernelImpl.java
@@ -203,7 +203,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             HBCIPassportInternal mainPassport=passports.getMainPassport();
 
             HBCIUtils.log("generating raw message "+currentMsgName,HBCIUtils.LOG_DEBUG);
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_MSG_CREATE,currentMsgName);
+            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.MSG_CREATE,currentMsgName);
 
             // plaintextnachricht erzeugen
             msg=gen.generate(currentMsgName);
@@ -245,7 +245,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             // wenn nachricht signiert werden soll
             if (signit) {
                 HBCIUtils.log("trying to insert signature",HBCIUtils.LOG_DEBUG);
-                HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_MSG_SIGN,null);
+                HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.MSG_SIGN,null);
                 
                 // signatur erzeugen und an nachricht anhängen
                 Sig sig=SigFactory.getInstance().createSig(getParentHandlerData(),msg,passports);
@@ -304,7 +304,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             // soll nachricht verschlüsselt werden?
             if (cryptit) {
                 HBCIUtils.log("trying to encrypt message",HBCIUtils.LOG_DEBUG);
-                HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_MSG_CRYPT,null);
+                HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.MSG_CRYPT,null);
                 
                 // nachricht verschlüsseln
                 MSG   old=msg;
@@ -353,7 +353,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             // ist antwortnachricht verschlüsselt?
             boolean crypted=msg.getName().equals("CryptedRes");
             if (crypted) {
-                HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_MSG_DECRYPT,null);
+                HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.MSG_DECRYPT,null);
                 
                 // wenn ja, dann nachricht entschlüsseln
                 HBCIUtils.log("acquire crypt instance",HBCIUtils.LOG_DEBUG);
@@ -363,7 +363,7 @@ public final class HBCIKernelImpl implements HBCIKernel
                     HBCIUtils.log("decrypting using " + crypt,HBCIUtils.LOG_DEBUG);
                     newmsgstring=crypt.decryptIt();
                     HBCIUtils.log("decrypted",HBCIUtils.LOG_DEBUG);
-                    HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_MSG_RAW_RECV,newmsgstring);
+                    HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.MSG_RAW_RECV,newmsgstring);
                 } finally {
                     HBCIUtils.log("free crypt",HBCIUtils.LOG_DEBUG);
                     CryptFactory.getInstance().unuseObject(crypt);
@@ -383,7 +383,7 @@ public final class HBCIKernelImpl implements HBCIKernel
                 
                 // nachricht als plaintextnachricht parsen
                 try {
-                    HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_MSG_PARSE,currentMsgName+"Res");
+                    HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.MSG_PARSE,currentMsgName+"Res");
                     HBCIUtils.log("message to pe parsed: "+msg.toString(0),HBCIUtils.LOG_DEBUG2);
                     MSG oldMsg=msg;
                     msg=MSGFactory.getInstance().createMSG(currentMsgName+"Res",newmsgstring,newmsgstring.length(),gen);
@@ -396,7 +396,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             }
             else
             {
-              HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_MSG_RAW_RECV,msg.toString(0));
+              HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.MSG_RAW_RECV,msg.toString(0));
             }
             
             HBCIUtils.log("received message after decryption: "+msg.toString(0),HBCIUtils.LOG_DEBUG2);
@@ -444,7 +444,7 @@ public final class HBCIKernelImpl implements HBCIKernel
             
             // überprüfen der signatur
             HBCIUtils.log("looking for a signature",HBCIUtils.LOG_DEBUG);
-            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.STATUS_MSG_VERIFY,null);
+            HBCIUtilsInternal.getCallback().status(mainPassport,HBCICallback.Status.MSG_VERIFY,null);
             boolean sigOk=false;
             Sig     sig=SigFactory.getInstance().createSig(getParentHandlerData(),msg,passports);
             try {

--- a/src/main/java/org/kapott/hbci/manager/HBCIUser.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUser.java
@@ -111,7 +111,7 @@ public final class HBCIUser implements IHandlerData
     @Deprecated
     private void doDialogEnd(String dialogid,String msgnum,boolean signIt,boolean cryptIt,boolean needCrypt)
     {
-        HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_DIALOG_END,null);
+        HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.DIALOG_END,null);
 
         kernel.rawNewMsg("DialogEnd"+anonSuffix);
         kernel.rawSet("MsgHead.dialogid",dialogid);
@@ -121,7 +121,7 @@ public final class HBCIUser implements IHandlerData
         HBCIMsgStatus status=kernel.rawDoIt(!isAnon && signIt,
                                             !isAnon && cryptIt,
                                             !isAnon && needCrypt);
-        HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_DIALOG_END_DONE,status);
+        HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.DIALOG_END_DONE,status);
 
         if (!status.isOK()) {
             HBCIUtils.log("dialog end failed: "+status.getErrorString(),HBCIUtils.LOG_ERR);
@@ -176,7 +176,7 @@ public final class HBCIUser implements IHandlerData
             if (!passport.hasMySigKey()) {
                 // es gibt noch gar keine Nutzerschluessel
                 
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_SEND_KEYS,null);
+                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.SEND_KEYS,null);
 
                 // sigid updated
                 passport.setSigId(new Long(1));
@@ -227,7 +227,7 @@ public final class HBCIUser implements IHandlerData
                 
                 Properties result=ret.getData();
                 
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_SEND_KEYS_DONE,ret);
+                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.SEND_KEYS_DONE,ret);
 
                 if (!ret.isOK()) {
                     if (!ret.hasExceptions()) {
@@ -257,7 +257,7 @@ public final class HBCIUser implements IHandlerData
             {
                 // aendern der aktuellen Nutzerschluessel
                 
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_DIALOG_INIT,null);
+                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.DIALOG_INIT,null);
 
                 // Dialog-Context erzeugen
                 final DialogContext ctx = DialogContext.create(this.kernel,this.passport);
@@ -276,10 +276,10 @@ public final class HBCIUser implements IHandlerData
                 inst.updateBPD(result);
                 this.updateUPD(result);
                 passport.saveChanges();
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_DIALOG_INIT_DONE,new Object[] {ret,result.getProperty("MsgHead.dialogid")});
+                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.DIALOG_INIT_DONE,new Object[] {ret,result.getProperty("MsgHead.dialogid")});
 
                 // neue Schlüssel senden
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_SEND_KEYS,null);
+                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.SEND_KEYS,null);
                 kernel.rawNewMsg("ChangeKeys");
                 kernel.rawSet("MsgHead.dialogid",result.getProperty("MsgHead.dialogid"));
                 kernel.rawSet("MsgHead.msgnum","2");
@@ -349,7 +349,7 @@ public final class HBCIUser implements IHandlerData
                 passport.saveChanges();
         
                 result = ret.getData();
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_SEND_KEYS_DONE,ret);
+                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.SEND_KEYS_DONE,ret);
                 doDialogEnd(result.getProperty("MsgHead.dialogid"),"3",HBCIKernelImpl.SIGNIT,HBCIKernelImpl.CRYPTIT,
                                                                        HBCIKernelImpl.NEED_CRYPT);
             }
@@ -424,7 +424,7 @@ public final class HBCIUser implements IHandlerData
     public void fetchSysId()
     {
         try {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INIT_SYSID,null);
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INIT_SYSID,null);
             HBCIUtils.log("Rufe neue System-ID ab",HBCIUtils.LOG_INFO);
             
             HBCIUtils.log("checking whether passport is supported (but ignoring result)",HBCIUtils.LOG_DEBUG);
@@ -449,7 +449,7 @@ public final class HBCIUser implements IHandlerData
                 passport.setSysId(result.getProperty("SyncRes.sysid"));
                 passport.saveChanges();
         
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INIT_SYSID_DONE,new Object[] {ret,passport.getSysId()});
+                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INIT_SYSID_DONE,new Object[] {ret,passport.getSysId()});
                 HBCIUtils.log("new sys-id is "+passport.getSysId(),HBCIUtils.LOG_DEBUG);
                 
                 final HBCIDialogEnd end = new HBCIDialogEnd();
@@ -472,7 +472,7 @@ public final class HBCIUser implements IHandlerData
     public void fetchSigId()
     {
         try {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INIT_SIGID,null);
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INIT_SIGID,null);
             HBCIUtils.log("Synchronisiere Signatur-ID",HBCIUtils.LOG_INFO);
             
             // autosecmech
@@ -497,7 +497,7 @@ public final class HBCIUser implements IHandlerData
             passport.incSigId();
             passport.saveChanges();
     
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INIT_SIGID_DONE,new Object[] {ret,passport.getSigId()});
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INIT_SIGID_DONE,new Object[] {ret,passport.getSigId()});
             HBCIUtils.log("signature id set to "+passport.getSigId(),HBCIUtils.LOG_DEBUG);
             
             final HBCIDialogEnd end = new HBCIDialogEnd(Flag.SIG_ID);
@@ -589,7 +589,7 @@ public final class HBCIUser implements IHandlerData
         final String newVersion = passport.getUPDVersion();
 
         HBCIUtils.log("Benutzerparameter (UPD) aktualisiert [Bisherige Version: " + oldVersion + ", neue Version: " + newVersion + "]",HBCIUtils.LOG_INFO);
-        HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INIT_UPD_DONE,passport.getUPD());
+        HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INIT_UPD_DONE,passport.getUPD());
     }
 
     /**
@@ -598,7 +598,7 @@ public final class HBCIUser implements IHandlerData
     public void fetchUPD()
     {
         try {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INIT_UPD,null);
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INIT_UPD,null);
             HBCIUtils.log("updating UPD (BPD-Version: " + passport.getBPDVersion() + ")",HBCIUtils.LOG_DEBUG);
             HBCIUtils.log("Aktualisiere Benutzerparameter (UPD)",HBCIUtils.LOG_INFO);
             
@@ -718,7 +718,7 @@ public final class HBCIUser implements IHandlerData
         }
         
         try {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_DIALOG_INIT,null);
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.DIALOG_INIT,null);
             HBCIUtils.log("Sperre Benutzerschlüssel",HBCIUtils.LOG_INFO);
             
             // Dialog-Context erzeugen
@@ -734,8 +734,8 @@ public final class HBCIUser implements IHandlerData
             final Properties result = ret.getData();
             
             String dialogid=result.getProperty("MsgHead.dialogid");
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_DIALOG_INIT_DONE,new Object[] {ret,dialogid});
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_LOCK_KEYS,null);
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.DIALOG_INIT_DONE,new Object[] {ret,dialogid});
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.LOCK_KEYS,null);
             
             final HBCIDialogLockKeys lock = new HBCIDialogLockKeys();
             ret = lock.execute(ctx);
@@ -747,7 +747,7 @@ public final class HBCIUser implements IHandlerData
             passport.setSigId(new Long(1));
             passport.saveChanges();
             
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_LOCK_KEYS_DONE,ret);
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.LOCK_KEYS_DONE,ret);
             final HBCIDialogEnd end = new HBCIDialogEnd();
             end.execute(ctx);
         } catch (Exception e) {

--- a/src/main/java/org/kapott/hbci/manager/HBCIUser.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUser.java
@@ -363,7 +363,7 @@ public final class HBCIUser implements IHandlerData
     {
         // TODO: hier überprüfen, ob tatsächlich ein INI-brief benötigt wird
         HBCIUtilsInternal.getCallback().callback(passport,
-                                         HBCICallback.HAVE_NEW_MY_KEYS,
+                                         HBCICallback.Reason.HAVE_NEW_MY_KEYS,
                                          HBCIUtilsInternal.getLocMsg("CALLB_NEW_USER_KEYS"),
                                          ResponseType.NONE,
                                          new StringBuffer());

--- a/src/main/java/org/kapott/hbci/manager/HBCIUser.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUser.java
@@ -364,7 +364,7 @@ public final class HBCIUser implements IHandlerData
         HBCIUtilsInternal.getCallback().callback(passport,
                                          HBCICallback.HAVE_NEW_MY_KEYS,
                                          HBCIUtilsInternal.getLocMsg("CALLB_NEW_USER_KEYS"),
-                                         HBCICallback.TYPE_NONE,
+                                         HBCICallback.ResponseType.TYPE_NONE,
                                          new StringBuffer());
         throw new NeedKeyAckException();
     }

--- a/src/main/java/org/kapott/hbci/manager/HBCIUser.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUser.java
@@ -35,6 +35,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.comm.Comm;
 import org.kapott.hbci.dialog.DialogContext;
 import org.kapott.hbci.dialog.HBCIDialogEnd;
@@ -364,7 +365,7 @@ public final class HBCIUser implements IHandlerData
         HBCIUtilsInternal.getCallback().callback(passport,
                                          HBCICallback.HAVE_NEW_MY_KEYS,
                                          HBCIUtilsInternal.getLocMsg("CALLB_NEW_USER_KEYS"),
-                                         HBCICallback.ResponseType.NONE,
+                                         ResponseType.NONE,
                                          new StringBuffer());
         throw new NeedKeyAckException();
     }

--- a/src/main/java/org/kapott/hbci/manager/HBCIUser.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUser.java
@@ -34,9 +34,9 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.kapott.hbci.callback.HBCICallback;
 import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
+import org.kapott.hbci.callback.HBCICallback.Status;
 import org.kapott.hbci.comm.Comm;
 import org.kapott.hbci.dialog.DialogContext;
 import org.kapott.hbci.dialog.HBCIDialogEnd;
@@ -111,7 +111,7 @@ public final class HBCIUser implements IHandlerData
     @Deprecated
     private void doDialogEnd(String dialogid,String msgnum,boolean signIt,boolean cryptIt,boolean needCrypt)
     {
-        HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.DIALOG_END,null);
+        HBCIUtilsInternal.getCallback().status(passport,Status.DIALOG_END,null);
 
         kernel.rawNewMsg("DialogEnd"+anonSuffix);
         kernel.rawSet("MsgHead.dialogid",dialogid);
@@ -121,7 +121,7 @@ public final class HBCIUser implements IHandlerData
         HBCIMsgStatus status=kernel.rawDoIt(!isAnon && signIt,
                                             !isAnon && cryptIt,
                                             !isAnon && needCrypt);
-        HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.DIALOG_END_DONE,status);
+        HBCIUtilsInternal.getCallback().status(passport,Status.DIALOG_END_DONE,status);
 
         if (!status.isOK()) {
             HBCIUtils.log("dialog end failed: "+status.getErrorString(),HBCIUtils.LOG_ERR);
@@ -176,7 +176,7 @@ public final class HBCIUser implements IHandlerData
             if (!passport.hasMySigKey()) {
                 // es gibt noch gar keine Nutzerschluessel
                 
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.SEND_KEYS,null);
+                HBCIUtilsInternal.getCallback().status(passport,Status.SEND_KEYS,null);
 
                 // sigid updated
                 passport.setSigId(new Long(1));
@@ -227,7 +227,7 @@ public final class HBCIUser implements IHandlerData
                 
                 Properties result=ret.getData();
                 
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.SEND_KEYS_DONE,ret);
+                HBCIUtilsInternal.getCallback().status(passport,Status.SEND_KEYS_DONE,ret);
 
                 if (!ret.isOK()) {
                     if (!ret.hasExceptions()) {
@@ -257,7 +257,7 @@ public final class HBCIUser implements IHandlerData
             {
                 // aendern der aktuellen Nutzerschluessel
                 
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.DIALOG_INIT,null);
+                HBCIUtilsInternal.getCallback().status(passport,Status.DIALOG_INIT,null);
 
                 // Dialog-Context erzeugen
                 final DialogContext ctx = DialogContext.create(this.kernel,this.passport);
@@ -276,10 +276,10 @@ public final class HBCIUser implements IHandlerData
                 inst.updateBPD(result);
                 this.updateUPD(result);
                 passport.saveChanges();
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.DIALOG_INIT_DONE,new Object[] {ret,result.getProperty("MsgHead.dialogid")});
+                HBCIUtilsInternal.getCallback().status(passport,Status.DIALOG_INIT_DONE,new Object[] {ret,result.getProperty("MsgHead.dialogid")});
 
                 // neue Schlüssel senden
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.SEND_KEYS,null);
+                HBCIUtilsInternal.getCallback().status(passport,Status.SEND_KEYS,null);
                 kernel.rawNewMsg("ChangeKeys");
                 kernel.rawSet("MsgHead.dialogid",result.getProperty("MsgHead.dialogid"));
                 kernel.rawSet("MsgHead.msgnum","2");
@@ -349,7 +349,7 @@ public final class HBCIUser implements IHandlerData
                 passport.saveChanges();
         
                 result = ret.getData();
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.SEND_KEYS_DONE,ret);
+                HBCIUtilsInternal.getCallback().status(passport,Status.SEND_KEYS_DONE,ret);
                 doDialogEnd(result.getProperty("MsgHead.dialogid"),"3",HBCIKernelImpl.SIGNIT,HBCIKernelImpl.CRYPTIT,
                                                                        HBCIKernelImpl.NEED_CRYPT);
             }
@@ -424,7 +424,7 @@ public final class HBCIUser implements IHandlerData
     public void fetchSysId()
     {
         try {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INIT_SYSID,null);
+            HBCIUtilsInternal.getCallback().status(passport,Status.INIT_SYSID,null);
             HBCIUtils.log("Rufe neue System-ID ab",HBCIUtils.LOG_INFO);
             
             HBCIUtils.log("checking whether passport is supported (but ignoring result)",HBCIUtils.LOG_DEBUG);
@@ -449,7 +449,7 @@ public final class HBCIUser implements IHandlerData
                 passport.setSysId(result.getProperty("SyncRes.sysid"));
                 passport.saveChanges();
         
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INIT_SYSID_DONE,new Object[] {ret,passport.getSysId()});
+                HBCIUtilsInternal.getCallback().status(passport,Status.INIT_SYSID_DONE,new Object[] {ret,passport.getSysId()});
                 HBCIUtils.log("new sys-id is "+passport.getSysId(),HBCIUtils.LOG_DEBUG);
                 
                 final HBCIDialogEnd end = new HBCIDialogEnd();
@@ -472,7 +472,7 @@ public final class HBCIUser implements IHandlerData
     public void fetchSigId()
     {
         try {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INIT_SIGID,null);
+            HBCIUtilsInternal.getCallback().status(passport,Status.INIT_SIGID,null);
             HBCIUtils.log("Synchronisiere Signatur-ID",HBCIUtils.LOG_INFO);
             
             // autosecmech
@@ -497,7 +497,7 @@ public final class HBCIUser implements IHandlerData
             passport.incSigId();
             passport.saveChanges();
     
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INIT_SIGID_DONE,new Object[] {ret,passport.getSigId()});
+            HBCIUtilsInternal.getCallback().status(passport,Status.INIT_SIGID_DONE,new Object[] {ret,passport.getSigId()});
             HBCIUtils.log("signature id set to "+passport.getSigId(),HBCIUtils.LOG_DEBUG);
             
             final HBCIDialogEnd end = new HBCIDialogEnd(Flag.SIG_ID);
@@ -589,7 +589,7 @@ public final class HBCIUser implements IHandlerData
         final String newVersion = passport.getUPDVersion();
 
         HBCIUtils.log("Benutzerparameter (UPD) aktualisiert [Bisherige Version: " + oldVersion + ", neue Version: " + newVersion + "]",HBCIUtils.LOG_INFO);
-        HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INIT_UPD_DONE,passport.getUPD());
+        HBCIUtilsInternal.getCallback().status(passport,Status.INIT_UPD_DONE,passport.getUPD());
     }
 
     /**
@@ -598,7 +598,7 @@ public final class HBCIUser implements IHandlerData
     public void fetchUPD()
     {
         try {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.INIT_UPD,null);
+            HBCIUtilsInternal.getCallback().status(passport,Status.INIT_UPD,null);
             HBCIUtils.log("updating UPD (BPD-Version: " + passport.getBPDVersion() + ")",HBCIUtils.LOG_DEBUG);
             HBCIUtils.log("Aktualisiere Benutzerparameter (UPD)",HBCIUtils.LOG_INFO);
             
@@ -718,7 +718,7 @@ public final class HBCIUser implements IHandlerData
         }
         
         try {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.DIALOG_INIT,null);
+            HBCIUtilsInternal.getCallback().status(passport,Status.DIALOG_INIT,null);
             HBCIUtils.log("Sperre Benutzerschlüssel",HBCIUtils.LOG_INFO);
             
             // Dialog-Context erzeugen
@@ -734,8 +734,8 @@ public final class HBCIUser implements IHandlerData
             final Properties result = ret.getData();
             
             String dialogid=result.getProperty("MsgHead.dialogid");
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.DIALOG_INIT_DONE,new Object[] {ret,dialogid});
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.LOCK_KEYS,null);
+            HBCIUtilsInternal.getCallback().status(passport,Status.DIALOG_INIT_DONE,new Object[] {ret,dialogid});
+            HBCIUtilsInternal.getCallback().status(passport,Status.LOCK_KEYS,null);
             
             final HBCIDialogLockKeys lock = new HBCIDialogLockKeys();
             ret = lock.execute(ctx);
@@ -747,7 +747,7 @@ public final class HBCIUser implements IHandlerData
             passport.setSigId(new Long(1));
             passport.saveChanges();
             
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.LOCK_KEYS_DONE,ret);
+            HBCIUtilsInternal.getCallback().status(passport,Status.LOCK_KEYS_DONE,ret);
             final HBCIDialogEnd end = new HBCIDialogEnd();
             end.execute(ctx);
         } catch (Exception e) {

--- a/src/main/java/org/kapott/hbci/manager/HBCIUser.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUser.java
@@ -111,7 +111,7 @@ public final class HBCIUser implements IHandlerData
     @Deprecated
     private void doDialogEnd(String dialogid,String msgnum,boolean signIt,boolean cryptIt,boolean needCrypt)
     {
-        HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_DIALOG_END,null);
+        HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_DIALOG_END,null);
 
         kernel.rawNewMsg("DialogEnd"+anonSuffix);
         kernel.rawSet("MsgHead.dialogid",dialogid);
@@ -121,7 +121,7 @@ public final class HBCIUser implements IHandlerData
         HBCIMsgStatus status=kernel.rawDoIt(!isAnon && signIt,
                                             !isAnon && cryptIt,
                                             !isAnon && needCrypt);
-        HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_DIALOG_END_DONE,status);
+        HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_DIALOG_END_DONE,status);
 
         if (!status.isOK()) {
             HBCIUtils.log("dialog end failed: "+status.getErrorString(),HBCIUtils.LOG_ERR);
@@ -176,7 +176,7 @@ public final class HBCIUser implements IHandlerData
             if (!passport.hasMySigKey()) {
                 // es gibt noch gar keine Nutzerschluessel
                 
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_SEND_KEYS,null);
+                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_SEND_KEYS,null);
 
                 // sigid updated
                 passport.setSigId(new Long(1));
@@ -227,7 +227,7 @@ public final class HBCIUser implements IHandlerData
                 
                 Properties result=ret.getData();
                 
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_SEND_KEYS_DONE,ret);
+                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_SEND_KEYS_DONE,ret);
 
                 if (!ret.isOK()) {
                     if (!ret.hasExceptions()) {
@@ -257,7 +257,7 @@ public final class HBCIUser implements IHandlerData
             {
                 // aendern der aktuellen Nutzerschluessel
                 
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_DIALOG_INIT,null);
+                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_DIALOG_INIT,null);
 
                 // Dialog-Context erzeugen
                 final DialogContext ctx = DialogContext.create(this.kernel,this.passport);
@@ -276,10 +276,10 @@ public final class HBCIUser implements IHandlerData
                 inst.updateBPD(result);
                 this.updateUPD(result);
                 passport.saveChanges();
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_DIALOG_INIT_DONE,new Object[] {ret,result.getProperty("MsgHead.dialogid")});
+                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_DIALOG_INIT_DONE,new Object[] {ret,result.getProperty("MsgHead.dialogid")});
 
                 // neue Schlüssel senden
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_SEND_KEYS,null);
+                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_SEND_KEYS,null);
                 kernel.rawNewMsg("ChangeKeys");
                 kernel.rawSet("MsgHead.dialogid",result.getProperty("MsgHead.dialogid"));
                 kernel.rawSet("MsgHead.msgnum","2");
@@ -349,7 +349,7 @@ public final class HBCIUser implements IHandlerData
                 passport.saveChanges();
         
                 result = ret.getData();
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_SEND_KEYS_DONE,ret);
+                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_SEND_KEYS_DONE,ret);
                 doDialogEnd(result.getProperty("MsgHead.dialogid"),"3",HBCIKernelImpl.SIGNIT,HBCIKernelImpl.CRYPTIT,
                                                                        HBCIKernelImpl.NEED_CRYPT);
             }
@@ -424,7 +424,7 @@ public final class HBCIUser implements IHandlerData
     public void fetchSysId()
     {
         try {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_INIT_SYSID,null);
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INIT_SYSID,null);
             HBCIUtils.log("Rufe neue System-ID ab",HBCIUtils.LOG_INFO);
             
             HBCIUtils.log("checking whether passport is supported (but ignoring result)",HBCIUtils.LOG_DEBUG);
@@ -449,7 +449,7 @@ public final class HBCIUser implements IHandlerData
                 passport.setSysId(result.getProperty("SyncRes.sysid"));
                 passport.saveChanges();
         
-                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_INIT_SYSID_DONE,new Object[] {ret,passport.getSysId()});
+                HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INIT_SYSID_DONE,new Object[] {ret,passport.getSysId()});
                 HBCIUtils.log("new sys-id is "+passport.getSysId(),HBCIUtils.LOG_DEBUG);
                 
                 final HBCIDialogEnd end = new HBCIDialogEnd();
@@ -472,7 +472,7 @@ public final class HBCIUser implements IHandlerData
     public void fetchSigId()
     {
         try {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_INIT_SIGID,null);
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INIT_SIGID,null);
             HBCIUtils.log("Synchronisiere Signatur-ID",HBCIUtils.LOG_INFO);
             
             // autosecmech
@@ -497,7 +497,7 @@ public final class HBCIUser implements IHandlerData
             passport.incSigId();
             passport.saveChanges();
     
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_INIT_SIGID_DONE,new Object[] {ret,passport.getSigId()});
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INIT_SIGID_DONE,new Object[] {ret,passport.getSigId()});
             HBCIUtils.log("signature id set to "+passport.getSigId(),HBCIUtils.LOG_DEBUG);
             
             final HBCIDialogEnd end = new HBCIDialogEnd(Flag.SIG_ID);
@@ -589,7 +589,7 @@ public final class HBCIUser implements IHandlerData
         final String newVersion = passport.getUPDVersion();
 
         HBCIUtils.log("Benutzerparameter (UPD) aktualisiert [Bisherige Version: " + oldVersion + ", neue Version: " + newVersion + "]",HBCIUtils.LOG_INFO);
-        HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_INIT_UPD_DONE,passport.getUPD());
+        HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INIT_UPD_DONE,passport.getUPD());
     }
 
     /**
@@ -598,7 +598,7 @@ public final class HBCIUser implements IHandlerData
     public void fetchUPD()
     {
         try {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_INIT_UPD,null);
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_INIT_UPD,null);
             HBCIUtils.log("updating UPD (BPD-Version: " + passport.getBPDVersion() + ")",HBCIUtils.LOG_DEBUG);
             HBCIUtils.log("Aktualisiere Benutzerparameter (UPD)",HBCIUtils.LOG_INFO);
             
@@ -718,7 +718,7 @@ public final class HBCIUser implements IHandlerData
         }
         
         try {
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_DIALOG_INIT,null);
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_DIALOG_INIT,null);
             HBCIUtils.log("Sperre Benutzerschlüssel",HBCIUtils.LOG_INFO);
             
             // Dialog-Context erzeugen
@@ -734,8 +734,8 @@ public final class HBCIUser implements IHandlerData
             final Properties result = ret.getData();
             
             String dialogid=result.getProperty("MsgHead.dialogid");
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_DIALOG_INIT_DONE,new Object[] {ret,dialogid});
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_LOCK_KEYS,null);
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_DIALOG_INIT_DONE,new Object[] {ret,dialogid});
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_LOCK_KEYS,null);
             
             final HBCIDialogLockKeys lock = new HBCIDialogLockKeys();
             ret = lock.execute(ctx);
@@ -747,7 +747,7 @@ public final class HBCIUser implements IHandlerData
             passport.setSigId(new Long(1));
             passport.saveChanges();
             
-            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.STATUS_LOCK_KEYS_DONE,ret);
+            HBCIUtilsInternal.getCallback().status(passport,HBCICallback.Status.STATUS_LOCK_KEYS_DONE,ret);
             final HBCIDialogEnd end = new HBCIDialogEnd();
             end.execute(ctx);
         } catch (Exception e) {

--- a/src/main/java/org/kapott/hbci/manager/HBCIUser.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUser.java
@@ -364,7 +364,7 @@ public final class HBCIUser implements IHandlerData
         HBCIUtilsInternal.getCallback().callback(passport,
                                          HBCICallback.HAVE_NEW_MY_KEYS,
                                          HBCIUtilsInternal.getLocMsg("CALLB_NEW_USER_KEYS"),
-                                         HBCICallback.ResponseType.TYPE_NONE,
+                                         HBCICallback.ResponseType.NONE,
                                          new StringBuffer());
         throw new NeedKeyAckException();
     }

--- a/src/main/java/org/kapott/hbci/manager/HBCIUser.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUser.java
@@ -35,6 +35,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.comm.Comm;
 import org.kapott.hbci.dialog.DialogContext;
@@ -363,7 +364,7 @@ public final class HBCIUser implements IHandlerData
     {
         // TODO: hier überprüfen, ob tatsächlich ein INI-brief benötigt wird
         HBCIUtilsInternal.getCallback().callback(passport,
-                                         HBCICallback.Reason.HAVE_NEW_MY_KEYS,
+                                         Reason.HAVE_NEW_MY_KEYS,
                                          HBCIUtilsInternal.getLocMsg("CALLB_NEW_USER_KEYS"),
                                          ResponseType.NONE,
                                          new StringBuffer());

--- a/src/main/java/org/kapott/hbci/manager/HBCIUtilsInternal.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUtilsInternal.java
@@ -33,6 +33,7 @@ import java.util.Properties;
 import java.util.ResourceBundle;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.passport.HBCIPassport;
 
@@ -143,7 +144,7 @@ public class HBCIUtilsInternal
         } else if (paramValue.equals("callback")) {
             StringBuffer sb=new StringBuffer();
             getCallback().callback(passport,
-                                   HBCICallback.Reason.HAVE_ERROR,
+                                   Reason.HAVE_ERROR,
                                    msg,
                                    ResponseType.BOOLEAN,
                                    sb);

--- a/src/main/java/org/kapott/hbci/manager/HBCIUtilsInternal.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUtilsInternal.java
@@ -144,7 +144,7 @@ public class HBCIUtilsInternal
             getCallback().callback(passport,
                                    HBCICallback.HAVE_ERROR,
                                    msg,
-                                   HBCICallback.ResponseType.TYPE_BOOLEAN,
+                                   HBCICallback.ResponseType.BOOLEAN,
                                    sb);
             if (sb.length()==0) {
                 HBCIUtils.log(msg,HBCIUtils.LOG_ERR);

--- a/src/main/java/org/kapott/hbci/manager/HBCIUtilsInternal.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUtilsInternal.java
@@ -143,7 +143,7 @@ public class HBCIUtilsInternal
         } else if (paramValue.equals("callback")) {
             StringBuffer sb=new StringBuffer();
             getCallback().callback(passport,
-                                   HBCICallback.HAVE_ERROR,
+                                   HBCICallback.Reason.HAVE_ERROR,
                                    msg,
                                    ResponseType.BOOLEAN,
                                    sb);

--- a/src/main/java/org/kapott/hbci/manager/HBCIUtilsInternal.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUtilsInternal.java
@@ -33,6 +33,7 @@ import java.util.Properties;
 import java.util.ResourceBundle;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.passport.HBCIPassport;
 
 public class HBCIUtilsInternal
@@ -144,7 +145,7 @@ public class HBCIUtilsInternal
             getCallback().callback(passport,
                                    HBCICallback.HAVE_ERROR,
                                    msg,
-                                   HBCICallback.ResponseType.BOOLEAN,
+                                   ResponseType.BOOLEAN,
                                    sb);
             if (sb.length()==0) {
                 HBCIUtils.log(msg,HBCIUtils.LOG_ERR);

--- a/src/main/java/org/kapott/hbci/manager/HBCIUtilsInternal.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUtilsInternal.java
@@ -144,7 +144,7 @@ public class HBCIUtilsInternal
             getCallback().callback(passport,
                                    HBCICallback.HAVE_ERROR,
                                    msg,
-                                   HBCICallback.TYPE_BOOLEAN,
+                                   HBCICallback.ResponseType.TYPE_BOOLEAN,
                                    sb);
             if (sb.length()==0) {
                 HBCIUtils.log(msg,HBCIUtils.LOG_ERR);

--- a/src/main/java/org/kapott/hbci/passport/AbstractHBCIPassport.java
+++ b/src/main/java/org/kapott/hbci/passport/AbstractHBCIPassport.java
@@ -91,7 +91,7 @@ public abstract class AbstractHBCIPassport
         if (needBLZ && 
             (getBLZ()==null || getBLZ().length()==0)) {
             StringBuffer sb=new StringBuffer();
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_BLZ,HBCIUtilsInternal.getLocMsg("BLZ"),ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_BLZ,HBCIUtilsInternal.getLocMsg("BLZ"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("BLZ")));
             setBLZ(sb.toString());
@@ -101,7 +101,7 @@ public abstract class AbstractHBCIPassport
         if (needCountry &&
             (getCountry()==null || getCountry().length()==0)) {
             StringBuffer sb=new StringBuffer("DE");
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_COUNTRY,HBCIUtilsInternal.getLocMsg("COUNTRY"),ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_COUNTRY,HBCIUtilsInternal.getLocMsg("COUNTRY"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("COUNTRY")));
             setCountry(sb.toString());
@@ -122,7 +122,7 @@ public abstract class AbstractHBCIPassport
                 sb=new StringBuffer(HBCIUtils.getHBCIHostForBLZ(getBLZ()));
             }
             
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_HOST,HBCIUtilsInternal.getLocMsg("HOST"),ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_HOST,HBCIUtilsInternal.getLocMsg("HOST"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("HOST")));
             setHost(sb.toString());
@@ -132,7 +132,7 @@ public abstract class AbstractHBCIPassport
         if (needPort && 
             (getPort()==null || getPort().intValue()==0)) {
             StringBuffer sb=new StringBuffer((this instanceof AbstractPinTanPassport) ? "443" : "3000");
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PORT,HBCIUtilsInternal.getLocMsg("PORT"),ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_PORT,HBCIUtilsInternal.getLocMsg("PORT"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("PORT")));
             setPort(new Integer(sb.toString()));
@@ -142,7 +142,7 @@ public abstract class AbstractHBCIPassport
         if (needFilter &&
                 (getFilterType()==null || getFilterType().length()==0)) {
             StringBuffer sb=new StringBuffer("Base64");
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_FILTER,HBCIUtilsInternal.getLocMsg("FILTER"),ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_FILTER,HBCIUtilsInternal.getLocMsg("FILTER"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("FILTER")));
             setFilterType(sb.toString());
@@ -152,7 +152,7 @@ public abstract class AbstractHBCIPassport
         if (needUserId &&
             (getUserId()==null || getUserId().length()==0)) {
             StringBuffer sb=new StringBuffer();
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_USERID,HBCIUtilsInternal.getLocMsg("USERID"),ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_USERID,HBCIUtilsInternal.getLocMsg("USERID"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("USERID")));
             setUserId(sb.toString());
@@ -162,7 +162,7 @@ public abstract class AbstractHBCIPassport
         if (needCustomerId &&
             (getStoredCustomerId()==null || getStoredCustomerId().length()==0)) {
             StringBuffer sb=new StringBuffer(getCustomerId());
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CUSTOMERID,HBCIUtilsInternal.getLocMsg("CUSTOMERID"),ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_CUSTOMERID,HBCIUtilsInternal.getLocMsg("CUSTOMERID"),ResponseType.TEXT,sb);
             setCustomerId(sb.toString());
             dataChanged=true;
         }

--- a/src/main/java/org/kapott/hbci/passport/AbstractHBCIPassport.java
+++ b/src/main/java/org/kapott/hbci/passport/AbstractHBCIPassport.java
@@ -90,7 +90,7 @@ public abstract class AbstractHBCIPassport
         if (needBLZ && 
             (getBLZ()==null || getBLZ().length()==0)) {
             StringBuffer sb=new StringBuffer();
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_BLZ,HBCIUtilsInternal.getLocMsg("BLZ"),HBCICallback.ResponseType.TYPE_TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_BLZ,HBCIUtilsInternal.getLocMsg("BLZ"),HBCICallback.ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("BLZ")));
             setBLZ(sb.toString());
@@ -100,7 +100,7 @@ public abstract class AbstractHBCIPassport
         if (needCountry &&
             (getCountry()==null || getCountry().length()==0)) {
             StringBuffer sb=new StringBuffer("DE");
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_COUNTRY,HBCIUtilsInternal.getLocMsg("COUNTRY"),HBCICallback.ResponseType.TYPE_TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_COUNTRY,HBCIUtilsInternal.getLocMsg("COUNTRY"),HBCICallback.ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("COUNTRY")));
             setCountry(sb.toString());
@@ -121,7 +121,7 @@ public abstract class AbstractHBCIPassport
                 sb=new StringBuffer(HBCIUtils.getHBCIHostForBLZ(getBLZ()));
             }
             
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_HOST,HBCIUtilsInternal.getLocMsg("HOST"),HBCICallback.ResponseType.TYPE_TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_HOST,HBCIUtilsInternal.getLocMsg("HOST"),HBCICallback.ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("HOST")));
             setHost(sb.toString());
@@ -131,7 +131,7 @@ public abstract class AbstractHBCIPassport
         if (needPort && 
             (getPort()==null || getPort().intValue()==0)) {
             StringBuffer sb=new StringBuffer((this instanceof AbstractPinTanPassport) ? "443" : "3000");
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PORT,HBCIUtilsInternal.getLocMsg("PORT"),HBCICallback.ResponseType.TYPE_TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PORT,HBCIUtilsInternal.getLocMsg("PORT"),HBCICallback.ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("PORT")));
             setPort(new Integer(sb.toString()));
@@ -141,7 +141,7 @@ public abstract class AbstractHBCIPassport
         if (needFilter &&
                 (getFilterType()==null || getFilterType().length()==0)) {
             StringBuffer sb=new StringBuffer("Base64");
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_FILTER,HBCIUtilsInternal.getLocMsg("FILTER"),HBCICallback.ResponseType.TYPE_TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_FILTER,HBCIUtilsInternal.getLocMsg("FILTER"),HBCICallback.ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("FILTER")));
             setFilterType(sb.toString());
@@ -151,7 +151,7 @@ public abstract class AbstractHBCIPassport
         if (needUserId &&
             (getUserId()==null || getUserId().length()==0)) {
             StringBuffer sb=new StringBuffer();
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_USERID,HBCIUtilsInternal.getLocMsg("USERID"),HBCICallback.ResponseType.TYPE_TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_USERID,HBCIUtilsInternal.getLocMsg("USERID"),HBCICallback.ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("USERID")));
             setUserId(sb.toString());
@@ -161,7 +161,7 @@ public abstract class AbstractHBCIPassport
         if (needCustomerId &&
             (getStoredCustomerId()==null || getStoredCustomerId().length()==0)) {
             StringBuffer sb=new StringBuffer(getCustomerId());
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CUSTOMERID,HBCIUtilsInternal.getLocMsg("CUSTOMERID"),HBCICallback.ResponseType.TYPE_TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CUSTOMERID,HBCIUtilsInternal.getLocMsg("CUSTOMERID"),HBCICallback.ResponseType.TEXT,sb);
             setCustomerId(sb.toString());
             dataChanged=true;
         }

--- a/src/main/java/org/kapott/hbci/passport/AbstractHBCIPassport.java
+++ b/src/main/java/org/kapott/hbci/passport/AbstractHBCIPassport.java
@@ -90,7 +90,7 @@ public abstract class AbstractHBCIPassport
         if (needBLZ && 
             (getBLZ()==null || getBLZ().length()==0)) {
             StringBuffer sb=new StringBuffer();
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_BLZ,HBCIUtilsInternal.getLocMsg("BLZ"),HBCICallback.TYPE_TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_BLZ,HBCIUtilsInternal.getLocMsg("BLZ"),HBCICallback.ResponseType.TYPE_TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("BLZ")));
             setBLZ(sb.toString());
@@ -100,7 +100,7 @@ public abstract class AbstractHBCIPassport
         if (needCountry &&
             (getCountry()==null || getCountry().length()==0)) {
             StringBuffer sb=new StringBuffer("DE");
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_COUNTRY,HBCIUtilsInternal.getLocMsg("COUNTRY"),HBCICallback.TYPE_TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_COUNTRY,HBCIUtilsInternal.getLocMsg("COUNTRY"),HBCICallback.ResponseType.TYPE_TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("COUNTRY")));
             setCountry(sb.toString());
@@ -121,7 +121,7 @@ public abstract class AbstractHBCIPassport
                 sb=new StringBuffer(HBCIUtils.getHBCIHostForBLZ(getBLZ()));
             }
             
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_HOST,HBCIUtilsInternal.getLocMsg("HOST"),HBCICallback.TYPE_TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_HOST,HBCIUtilsInternal.getLocMsg("HOST"),HBCICallback.ResponseType.TYPE_TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("HOST")));
             setHost(sb.toString());
@@ -131,7 +131,7 @@ public abstract class AbstractHBCIPassport
         if (needPort && 
             (getPort()==null || getPort().intValue()==0)) {
             StringBuffer sb=new StringBuffer((this instanceof AbstractPinTanPassport) ? "443" : "3000");
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PORT,HBCIUtilsInternal.getLocMsg("PORT"),HBCICallback.TYPE_TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PORT,HBCIUtilsInternal.getLocMsg("PORT"),HBCICallback.ResponseType.TYPE_TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("PORT")));
             setPort(new Integer(sb.toString()));
@@ -141,7 +141,7 @@ public abstract class AbstractHBCIPassport
         if (needFilter &&
                 (getFilterType()==null || getFilterType().length()==0)) {
             StringBuffer sb=new StringBuffer("Base64");
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_FILTER,HBCIUtilsInternal.getLocMsg("FILTER"),HBCICallback.TYPE_TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_FILTER,HBCIUtilsInternal.getLocMsg("FILTER"),HBCICallback.ResponseType.TYPE_TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("FILTER")));
             setFilterType(sb.toString());
@@ -151,7 +151,7 @@ public abstract class AbstractHBCIPassport
         if (needUserId &&
             (getUserId()==null || getUserId().length()==0)) {
             StringBuffer sb=new StringBuffer();
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_USERID,HBCIUtilsInternal.getLocMsg("USERID"),HBCICallback.TYPE_TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_USERID,HBCIUtilsInternal.getLocMsg("USERID"),HBCICallback.ResponseType.TYPE_TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("USERID")));
             setUserId(sb.toString());
@@ -161,7 +161,7 @@ public abstract class AbstractHBCIPassport
         if (needCustomerId &&
             (getStoredCustomerId()==null || getStoredCustomerId().length()==0)) {
             StringBuffer sb=new StringBuffer(getCustomerId());
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CUSTOMERID,HBCIUtilsInternal.getLocMsg("CUSTOMERID"),HBCICallback.TYPE_TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CUSTOMERID,HBCIUtilsInternal.getLocMsg("CUSTOMERID"),HBCICallback.ResponseType.TYPE_TEXT,sb);
             setCustomerId(sb.toString());
             dataChanged=true;
         }

--- a/src/main/java/org/kapott/hbci/passport/AbstractHBCIPassport.java
+++ b/src/main/java/org/kapott/hbci/passport/AbstractHBCIPassport.java
@@ -31,6 +31,7 @@ import java.util.Hashtable;
 import java.util.Properties;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.comm.Comm;
 import org.kapott.hbci.comm.Filter;
 import org.kapott.hbci.dialog.DialogContext;
@@ -90,7 +91,7 @@ public abstract class AbstractHBCIPassport
         if (needBLZ && 
             (getBLZ()==null || getBLZ().length()==0)) {
             StringBuffer sb=new StringBuffer();
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_BLZ,HBCIUtilsInternal.getLocMsg("BLZ"),HBCICallback.ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_BLZ,HBCIUtilsInternal.getLocMsg("BLZ"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("BLZ")));
             setBLZ(sb.toString());
@@ -100,7 +101,7 @@ public abstract class AbstractHBCIPassport
         if (needCountry &&
             (getCountry()==null || getCountry().length()==0)) {
             StringBuffer sb=new StringBuffer("DE");
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_COUNTRY,HBCIUtilsInternal.getLocMsg("COUNTRY"),HBCICallback.ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_COUNTRY,HBCIUtilsInternal.getLocMsg("COUNTRY"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("COUNTRY")));
             setCountry(sb.toString());
@@ -121,7 +122,7 @@ public abstract class AbstractHBCIPassport
                 sb=new StringBuffer(HBCIUtils.getHBCIHostForBLZ(getBLZ()));
             }
             
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_HOST,HBCIUtilsInternal.getLocMsg("HOST"),HBCICallback.ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_HOST,HBCIUtilsInternal.getLocMsg("HOST"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("HOST")));
             setHost(sb.toString());
@@ -131,7 +132,7 @@ public abstract class AbstractHBCIPassport
         if (needPort && 
             (getPort()==null || getPort().intValue()==0)) {
             StringBuffer sb=new StringBuffer((this instanceof AbstractPinTanPassport) ? "443" : "3000");
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PORT,HBCIUtilsInternal.getLocMsg("PORT"),HBCICallback.ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PORT,HBCIUtilsInternal.getLocMsg("PORT"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("PORT")));
             setPort(new Integer(sb.toString()));
@@ -141,7 +142,7 @@ public abstract class AbstractHBCIPassport
         if (needFilter &&
                 (getFilterType()==null || getFilterType().length()==0)) {
             StringBuffer sb=new StringBuffer("Base64");
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_FILTER,HBCIUtilsInternal.getLocMsg("FILTER"),HBCICallback.ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_FILTER,HBCIUtilsInternal.getLocMsg("FILTER"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("FILTER")));
             setFilterType(sb.toString());
@@ -151,7 +152,7 @@ public abstract class AbstractHBCIPassport
         if (needUserId &&
             (getUserId()==null || getUserId().length()==0)) {
             StringBuffer sb=new StringBuffer();
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_USERID,HBCIUtilsInternal.getLocMsg("USERID"),HBCICallback.ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_USERID,HBCIUtilsInternal.getLocMsg("USERID"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("USERID")));
             setUserId(sb.toString());
@@ -161,7 +162,7 @@ public abstract class AbstractHBCIPassport
         if (needCustomerId &&
             (getStoredCustomerId()==null || getStoredCustomerId().length()==0)) {
             StringBuffer sb=new StringBuffer(getCustomerId());
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CUSTOMERID,HBCIUtilsInternal.getLocMsg("CUSTOMERID"),HBCICallback.ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CUSTOMERID,HBCIUtilsInternal.getLocMsg("CUSTOMERID"),ResponseType.TEXT,sb);
             setCustomerId(sb.toString());
             dataChanged=true;
         }

--- a/src/main/java/org/kapott/hbci/passport/AbstractHBCIPassport.java
+++ b/src/main/java/org/kapott/hbci/passport/AbstractHBCIPassport.java
@@ -30,7 +30,7 @@ import java.util.Enumeration;
 import java.util.Hashtable;
 import java.util.Properties;
 
-import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.comm.Comm;
 import org.kapott.hbci.comm.Filter;
@@ -91,7 +91,7 @@ public abstract class AbstractHBCIPassport
         if (needBLZ && 
             (getBLZ()==null || getBLZ().length()==0)) {
             StringBuffer sb=new StringBuffer();
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_BLZ,HBCIUtilsInternal.getLocMsg("BLZ"),ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,Reason.NEED_BLZ,HBCIUtilsInternal.getLocMsg("BLZ"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("BLZ")));
             setBLZ(sb.toString());
@@ -101,7 +101,7 @@ public abstract class AbstractHBCIPassport
         if (needCountry &&
             (getCountry()==null || getCountry().length()==0)) {
             StringBuffer sb=new StringBuffer("DE");
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_COUNTRY,HBCIUtilsInternal.getLocMsg("COUNTRY"),ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,Reason.NEED_COUNTRY,HBCIUtilsInternal.getLocMsg("COUNTRY"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("COUNTRY")));
             setCountry(sb.toString());
@@ -122,7 +122,7 @@ public abstract class AbstractHBCIPassport
                 sb=new StringBuffer(HBCIUtils.getHBCIHostForBLZ(getBLZ()));
             }
             
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_HOST,HBCIUtilsInternal.getLocMsg("HOST"),ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,Reason.NEED_HOST,HBCIUtilsInternal.getLocMsg("HOST"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("HOST")));
             setHost(sb.toString());
@@ -132,7 +132,7 @@ public abstract class AbstractHBCIPassport
         if (needPort && 
             (getPort()==null || getPort().intValue()==0)) {
             StringBuffer sb=new StringBuffer((this instanceof AbstractPinTanPassport) ? "443" : "3000");
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_PORT,HBCIUtilsInternal.getLocMsg("PORT"),ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,Reason.NEED_PORT,HBCIUtilsInternal.getLocMsg("PORT"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("PORT")));
             setPort(new Integer(sb.toString()));
@@ -142,7 +142,7 @@ public abstract class AbstractHBCIPassport
         if (needFilter &&
                 (getFilterType()==null || getFilterType().length()==0)) {
             StringBuffer sb=new StringBuffer("Base64");
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_FILTER,HBCIUtilsInternal.getLocMsg("FILTER"),ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,Reason.NEED_FILTER,HBCIUtilsInternal.getLocMsg("FILTER"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("FILTER")));
             setFilterType(sb.toString());
@@ -152,7 +152,7 @@ public abstract class AbstractHBCIPassport
         if (needUserId &&
             (getUserId()==null || getUserId().length()==0)) {
             StringBuffer sb=new StringBuffer();
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_USERID,HBCIUtilsInternal.getLocMsg("USERID"),ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,Reason.NEED_USERID,HBCIUtilsInternal.getLocMsg("USERID"),ResponseType.TEXT,sb);
             if (sb.length()==0)
                 throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_EMPTY_X",HBCIUtilsInternal.getLocMsg("USERID")));
             setUserId(sb.toString());
@@ -162,7 +162,7 @@ public abstract class AbstractHBCIPassport
         if (needCustomerId &&
             (getStoredCustomerId()==null || getStoredCustomerId().length()==0)) {
             StringBuffer sb=new StringBuffer(getCustomerId());
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_CUSTOMERID,HBCIUtilsInternal.getLocMsg("CUSTOMERID"),ResponseType.TEXT,sb);
+            HBCIUtilsInternal.getCallback().callback(this,Reason.NEED_CUSTOMERID,HBCIUtilsInternal.getLocMsg("CUSTOMERID"),ResponseType.TEXT,sb);
             setCustomerId(sb.toString());
             dataChanged=true;
         }

--- a/src/main/java/org/kapott/hbci/passport/AbstractPinTanPassport.java
+++ b/src/main/java/org/kapott/hbci/passport/AbstractPinTanPassport.java
@@ -34,6 +34,7 @@ import java.util.Set;
 import org.kapott.hbci.GV.GVTAN2Step;
 import org.kapott.hbci.GV.HBCIJobImpl;
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.comm.Comm;
 import org.kapott.hbci.dialog.DialogContext;
 import org.kapott.hbci.dialog.DialogEvent;
@@ -292,7 +293,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
         this.clearPIN();
         
         // Aufrufer informieren, dass falsche PIN eingegeben wurde (um evtl. PIN aus Puffer zu löschen, etc.) 
-        HBCIUtilsInternal.getCallback().callback(this,HBCICallback.WRONG_PIN,"*** invalid PIN entered",HBCICallback.ResponseType.TEXT,new StringBuffer());
+        HBCIUtilsInternal.getCallback().callback(this,HBCICallback.WRONG_PIN,"*** invalid PIN entered",ResponseType.TEXT,new StringBuffer());
     }
     
     /**
@@ -424,7 +425,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
             // Aufrufer informieren, dass UserID und CustomerID geändert wurde
             StringBuffer retData=new StringBuffer();
             retData.append(newUserId+"|"+newCustomerId);
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.USERID_CHANGED,"*** User ID changed",HBCICallback.ResponseType.TEXT,retData);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.USERID_CHANGED,"*** User ID changed",ResponseType.TEXT,retData);
         }
     }
 
@@ -965,7 +966,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
             retData.append(entry.getId()).append(":").append(entry.getName());
         }
         
-        HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PT_SECMECH,"*** Select a pintan method from the list",HBCICallback.ResponseType.TEXT,retData);
+        HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PT_SECMECH,"*** Select a pintan method from the list",ResponseType.TEXT,retData);
         
         // Pruefen, ob das gewaehlte Verfahren einem aus der Liste entspricht
         final String selected = retData.toString();
@@ -1606,7 +1607,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
             if (upd != null)
                 retData.append(upd.getProperty(HBCIUser.UPD_KEY_TANMEDIA,""));
             
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PT_TANMEDIA,"*** Enter the name of your TAN media",HBCICallback.ResponseType.TEXT,retData);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PT_TANMEDIA,"*** Enter the name of your TAN media",ResponseType.TEXT,retData);
             final String result = retData.toString();
             if (StringUtil.hasText(result))
                 return result;

--- a/src/main/java/org/kapott/hbci/passport/AbstractPinTanPassport.java
+++ b/src/main/java/org/kapott/hbci/passport/AbstractPinTanPassport.java
@@ -292,7 +292,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
         this.clearPIN();
         
         // Aufrufer informieren, dass falsche PIN eingegeben wurde (um evtl. PIN aus Puffer zu löschen, etc.) 
-        HBCIUtilsInternal.getCallback().callback(this,HBCICallback.WRONG_PIN,"*** invalid PIN entered",HBCICallback.TYPE_TEXT,new StringBuffer());
+        HBCIUtilsInternal.getCallback().callback(this,HBCICallback.WRONG_PIN,"*** invalid PIN entered",HBCICallback.ResponseType.TYPE_TEXT,new StringBuffer());
     }
     
     /**
@@ -424,7 +424,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
             // Aufrufer informieren, dass UserID und CustomerID geändert wurde
             StringBuffer retData=new StringBuffer();
             retData.append(newUserId+"|"+newCustomerId);
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.USERID_CHANGED,"*** User ID changed",HBCICallback.TYPE_TEXT,retData);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.USERID_CHANGED,"*** User ID changed",HBCICallback.ResponseType.TYPE_TEXT,retData);
         }
     }
 
@@ -965,7 +965,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
             retData.append(entry.getId()).append(":").append(entry.getName());
         }
         
-        HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PT_SECMECH,"*** Select a pintan method from the list",HBCICallback.TYPE_TEXT,retData);
+        HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PT_SECMECH,"*** Select a pintan method from the list",HBCICallback.ResponseType.TYPE_TEXT,retData);
         
         // Pruefen, ob das gewaehlte Verfahren einem aus der Liste entspricht
         final String selected = retData.toString();
@@ -1606,7 +1606,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
             if (upd != null)
                 retData.append(upd.getProperty(HBCIUser.UPD_KEY_TANMEDIA,""));
             
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PT_TANMEDIA,"*** Enter the name of your TAN media",HBCICallback.TYPE_TEXT,retData);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PT_TANMEDIA,"*** Enter the name of your TAN media",HBCICallback.ResponseType.TYPE_TEXT,retData);
             final String result = retData.toString();
             if (StringUtil.hasText(result))
                 return result;

--- a/src/main/java/org/kapott/hbci/passport/AbstractPinTanPassport.java
+++ b/src/main/java/org/kapott/hbci/passport/AbstractPinTanPassport.java
@@ -293,7 +293,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
         this.clearPIN();
         
         // Aufrufer informieren, dass falsche PIN eingegeben wurde (um evtl. PIN aus Puffer zu löschen, etc.) 
-        HBCIUtilsInternal.getCallback().callback(this,HBCICallback.WRONG_PIN,"*** invalid PIN entered",ResponseType.TEXT,new StringBuffer());
+        HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.WRONG_PIN,"*** invalid PIN entered",ResponseType.TEXT,new StringBuffer());
     }
     
     /**
@@ -425,7 +425,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
             // Aufrufer informieren, dass UserID und CustomerID geändert wurde
             StringBuffer retData=new StringBuffer();
             retData.append(newUserId+"|"+newCustomerId);
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.USERID_CHANGED,"*** User ID changed",ResponseType.TEXT,retData);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.USERID_CHANGED,"*** User ID changed",ResponseType.TEXT,retData);
         }
     }
 
@@ -966,7 +966,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
             retData.append(entry.getId()).append(":").append(entry.getName());
         }
         
-        HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PT_SECMECH,"*** Select a pintan method from the list",ResponseType.TEXT,retData);
+        HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_PT_SECMECH,"*** Select a pintan method from the list",ResponseType.TEXT,retData);
         
         // Pruefen, ob das gewaehlte Verfahren einem aus der Liste entspricht
         final String selected = retData.toString();
@@ -1607,7 +1607,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
             if (upd != null)
                 retData.append(upd.getProperty(HBCIUser.UPD_KEY_TANMEDIA,""));
             
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PT_TANMEDIA,"*** Enter the name of your TAN media",ResponseType.TEXT,retData);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_PT_TANMEDIA,"*** Enter the name of your TAN media",ResponseType.TEXT,retData);
             final String result = retData.toString();
             if (StringUtil.hasText(result))
                 return result;

--- a/src/main/java/org/kapott/hbci/passport/AbstractPinTanPassport.java
+++ b/src/main/java/org/kapott/hbci/passport/AbstractPinTanPassport.java
@@ -292,7 +292,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
         this.clearPIN();
         
         // Aufrufer informieren, dass falsche PIN eingegeben wurde (um evtl. PIN aus Puffer zu löschen, etc.) 
-        HBCIUtilsInternal.getCallback().callback(this,HBCICallback.WRONG_PIN,"*** invalid PIN entered",HBCICallback.ResponseType.TYPE_TEXT,new StringBuffer());
+        HBCIUtilsInternal.getCallback().callback(this,HBCICallback.WRONG_PIN,"*** invalid PIN entered",HBCICallback.ResponseType.TEXT,new StringBuffer());
     }
     
     /**
@@ -424,7 +424,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
             // Aufrufer informieren, dass UserID und CustomerID geändert wurde
             StringBuffer retData=new StringBuffer();
             retData.append(newUserId+"|"+newCustomerId);
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.USERID_CHANGED,"*** User ID changed",HBCICallback.ResponseType.TYPE_TEXT,retData);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.USERID_CHANGED,"*** User ID changed",HBCICallback.ResponseType.TEXT,retData);
         }
     }
 
@@ -965,7 +965,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
             retData.append(entry.getId()).append(":").append(entry.getName());
         }
         
-        HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PT_SECMECH,"*** Select a pintan method from the list",HBCICallback.ResponseType.TYPE_TEXT,retData);
+        HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PT_SECMECH,"*** Select a pintan method from the list",HBCICallback.ResponseType.TEXT,retData);
         
         // Pruefen, ob das gewaehlte Verfahren einem aus der Liste entspricht
         final String selected = retData.toString();
@@ -1606,7 +1606,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
             if (upd != null)
                 retData.append(upd.getProperty(HBCIUser.UPD_KEY_TANMEDIA,""));
             
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PT_TANMEDIA,"*** Enter the name of your TAN media",HBCICallback.ResponseType.TYPE_TEXT,retData);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_PT_TANMEDIA,"*** Enter the name of your TAN media",HBCICallback.ResponseType.TEXT,retData);
             final String result = retData.toString();
             if (StringUtil.hasText(result))
                 return result;

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportDDV.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportDDV.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 
 import org.kapott.cryptalgs.CryptAlgs4JavaProvider;
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.exceptions.HBCI_Exception;
 import org.kapott.hbci.manager.HBCIKey;
 import org.kapott.hbci.manager.HBCIUtils;
@@ -138,9 +139,9 @@ public class HBCIPassportDDV extends AbstractDDVPassport
         HBCIUtils.log("using chipcard terminal with port "+comport+" and terminal number "+ctnumber,HBCIUtils.LOG_DEBUG);
         try
         {
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),HBCICallback.ResponseType.NONE,null);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),ResponseType.NONE,null);
             initCT();
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.HAVE_CHIPCARD,"",HBCICallback.ResponseType.NONE,null);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.HAVE_CHIPCARD,"",ResponseType.NONE,null);
             
             this.ctReadBankData();
 
@@ -484,7 +485,7 @@ public class HBCIPassportDDV extends AbstractDDVPassport
                         HBCIUtilsInternal.getCallback().callback(this,
                                                          HBCICallback.NEED_SOFTPIN,
                                                          HBCIUtilsInternal.getLocMsg("CALLB_NEED_SOFTPIN"),
-                                                         HBCICallback.ResponseType.SECRET,
+                                                         ResponseType.SECRET,
                                                          temppin);
                         if (temppin.length()==0)
                             throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("EXCMSG_PINZERO"));
@@ -497,7 +498,7 @@ public class HBCIPassportDDV extends AbstractDDVPassport
                     HBCIUtilsInternal.getCallback().callback(this,
                                                      HBCICallback.NEED_HARDPIN,
                                                      HBCIUtilsInternal.getLocMsg("CALLB_NEED_HARDPIN"),
-                                                     HBCICallback.ResponseType.NONE,
+                                                     ResponseType.NONE,
                                                      null);
                 }
 
@@ -512,7 +513,7 @@ public class HBCIPassportDDV extends AbstractDDVPassport
                         HBCIUtilsInternal.getCallback().callback(this,
                                                          HBCICallback.HAVE_HARDPIN,
                                                          null,
-                                                         HBCICallback.ResponseType.NONE,
+                                                         ResponseType.NONE,
                                                          null);
                     }
                 }

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportDDV.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportDDV.java
@@ -138,9 +138,9 @@ public class HBCIPassportDDV extends AbstractDDVPassport
         HBCIUtils.log("using chipcard terminal with port "+comport+" and terminal number "+ctnumber,HBCIUtils.LOG_DEBUG);
         try
         {
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),HBCICallback.ResponseType.TYPE_NONE,null);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),HBCICallback.ResponseType.NONE,null);
             initCT();
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.HAVE_CHIPCARD,"",HBCICallback.ResponseType.TYPE_NONE,null);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.HAVE_CHIPCARD,"",HBCICallback.ResponseType.NONE,null);
             
             this.ctReadBankData();
 
@@ -484,7 +484,7 @@ public class HBCIPassportDDV extends AbstractDDVPassport
                         HBCIUtilsInternal.getCallback().callback(this,
                                                          HBCICallback.NEED_SOFTPIN,
                                                          HBCIUtilsInternal.getLocMsg("CALLB_NEED_SOFTPIN"),
-                                                         HBCICallback.ResponseType.TYPE_SECRET,
+                                                         HBCICallback.ResponseType.SECRET,
                                                          temppin);
                         if (temppin.length()==0)
                             throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("EXCMSG_PINZERO"));
@@ -497,7 +497,7 @@ public class HBCIPassportDDV extends AbstractDDVPassport
                     HBCIUtilsInternal.getCallback().callback(this,
                                                      HBCICallback.NEED_HARDPIN,
                                                      HBCIUtilsInternal.getLocMsg("CALLB_NEED_HARDPIN"),
-                                                     HBCICallback.ResponseType.TYPE_NONE,
+                                                     HBCICallback.ResponseType.NONE,
                                                      null);
                 }
 
@@ -512,7 +512,7 @@ public class HBCIPassportDDV extends AbstractDDVPassport
                         HBCIUtilsInternal.getCallback().callback(this,
                                                          HBCICallback.HAVE_HARDPIN,
                                                          null,
-                                                         HBCICallback.ResponseType.TYPE_NONE,
+                                                         HBCICallback.ResponseType.NONE,
                                                          null);
                     }
                 }

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportDDV.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportDDV.java
@@ -139,9 +139,9 @@ public class HBCIPassportDDV extends AbstractDDVPassport
         HBCIUtils.log("using chipcard terminal with port "+comport+" and terminal number "+ctnumber,HBCIUtils.LOG_DEBUG);
         try
         {
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),ResponseType.NONE,null);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),ResponseType.NONE,null);
             initCT();
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.HAVE_CHIPCARD,"",ResponseType.NONE,null);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.HAVE_CHIPCARD,"",ResponseType.NONE,null);
             
             this.ctReadBankData();
 
@@ -483,7 +483,7 @@ public class HBCIPassportDDV extends AbstractDDVPassport
                     if (pin==null || pin.length()==0) {
                         StringBuffer temppin=new StringBuffer();
                         HBCIUtilsInternal.getCallback().callback(this,
-                                                         HBCICallback.NEED_SOFTPIN,
+                                                         HBCICallback.Reason.NEED_SOFTPIN,
                                                          HBCIUtilsInternal.getLocMsg("CALLB_NEED_SOFTPIN"),
                                                          ResponseType.SECRET,
                                                          temppin);
@@ -496,7 +496,7 @@ public class HBCIPassportDDV extends AbstractDDVPassport
                     setSoftPin(pin.getBytes("ISO-8859-1"));
                 } else {
                     HBCIUtilsInternal.getCallback().callback(this,
-                                                     HBCICallback.NEED_HARDPIN,
+                                                     HBCICallback.Reason.NEED_HARDPIN,
                                                      HBCIUtilsInternal.getLocMsg("CALLB_NEED_HARDPIN"),
                                                      ResponseType.NONE,
                                                      null);
@@ -511,7 +511,7 @@ public class HBCIPassportDDV extends AbstractDDVPassport
                 } finally {
                     if (useSoftPin!=1) {
                         HBCIUtilsInternal.getCallback().callback(this,
-                                                         HBCICallback.HAVE_HARDPIN,
+                                                         HBCICallback.Reason.HAVE_HARDPIN,
                                                          null,
                                                          ResponseType.NONE,
                                                          null);

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportDDV.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportDDV.java
@@ -21,17 +21,16 @@
 
 package org.kapott.hbci.passport;
 
-import java.io.File;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.util.Arrays;
-
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.DESedeKeySpec;
 import javax.crypto.spec.IvParameterSpec;
+import java.io.File;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.util.Arrays;
 
 import org.kapott.cryptalgs.CryptAlgs4JavaProvider;
 import org.kapott.hbci.callback.HBCICallback;
@@ -139,9 +138,9 @@ public class HBCIPassportDDV extends AbstractDDVPassport
         HBCIUtils.log("using chipcard terminal with port "+comport+" and terminal number "+ctnumber,HBCIUtils.LOG_DEBUG);
         try
         {
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),HBCICallback.TYPE_NONE,null);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),HBCICallback.ResponseType.TYPE_NONE,null);
             initCT();
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.HAVE_CHIPCARD,"",HBCICallback.TYPE_NONE,null);
+            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.HAVE_CHIPCARD,"",HBCICallback.ResponseType.TYPE_NONE,null);
             
             this.ctReadBankData();
 
@@ -485,7 +484,7 @@ public class HBCIPassportDDV extends AbstractDDVPassport
                         HBCIUtilsInternal.getCallback().callback(this,
                                                          HBCICallback.NEED_SOFTPIN,
                                                          HBCIUtilsInternal.getLocMsg("CALLB_NEED_SOFTPIN"),
-                                                         HBCICallback.TYPE_SECRET,
+                                                         HBCICallback.ResponseType.TYPE_SECRET,
                                                          temppin);
                         if (temppin.length()==0)
                             throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("EXCMSG_PINZERO"));
@@ -498,7 +497,7 @@ public class HBCIPassportDDV extends AbstractDDVPassport
                     HBCIUtilsInternal.getCallback().callback(this,
                                                      HBCICallback.NEED_HARDPIN,
                                                      HBCIUtilsInternal.getLocMsg("CALLB_NEED_HARDPIN"),
-                                                     HBCICallback.TYPE_NONE,
+                                                     HBCICallback.ResponseType.TYPE_NONE,
                                                      null);
                 }
 
@@ -513,7 +512,7 @@ public class HBCIPassportDDV extends AbstractDDVPassport
                         HBCIUtilsInternal.getCallback().callback(this,
                                                          HBCICallback.HAVE_HARDPIN,
                                                          null,
-                                                         HBCICallback.TYPE_NONE,
+                                                         HBCICallback.ResponseType.TYPE_NONE,
                                                          null);
                     }
                 }

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportDDV.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportDDV.java
@@ -33,7 +33,7 @@ import java.security.NoSuchProviderException;
 import java.util.Arrays;
 
 import org.kapott.cryptalgs.CryptAlgs4JavaProvider;
-import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.exceptions.HBCI_Exception;
 import org.kapott.hbci.manager.HBCIKey;
@@ -139,9 +139,9 @@ public class HBCIPassportDDV extends AbstractDDVPassport
         HBCIUtils.log("using chipcard terminal with port "+comport+" and terminal number "+ctnumber,HBCIUtils.LOG_DEBUG);
         try
         {
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),ResponseType.NONE,null);
+            HBCIUtilsInternal.getCallback().callback(this,Reason.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),ResponseType.NONE,null);
             initCT();
-            HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.HAVE_CHIPCARD,"",ResponseType.NONE,null);
+            HBCIUtilsInternal.getCallback().callback(this,Reason.HAVE_CHIPCARD,"",ResponseType.NONE,null);
             
             this.ctReadBankData();
 
@@ -483,7 +483,7 @@ public class HBCIPassportDDV extends AbstractDDVPassport
                     if (pin==null || pin.length()==0) {
                         StringBuffer temppin=new StringBuffer();
                         HBCIUtilsInternal.getCallback().callback(this,
-                                                         HBCICallback.Reason.NEED_SOFTPIN,
+                                                         Reason.NEED_SOFTPIN,
                                                          HBCIUtilsInternal.getLocMsg("CALLB_NEED_SOFTPIN"),
                                                          ResponseType.SECRET,
                                                          temppin);
@@ -496,7 +496,7 @@ public class HBCIPassportDDV extends AbstractDDVPassport
                     setSoftPin(pin.getBytes("ISO-8859-1"));
                 } else {
                     HBCIUtilsInternal.getCallback().callback(this,
-                                                     HBCICallback.Reason.NEED_HARDPIN,
+                                                     Reason.NEED_HARDPIN,
                                                      HBCIUtilsInternal.getLocMsg("CALLB_NEED_HARDPIN"),
                                                      ResponseType.NONE,
                                                      null);
@@ -511,7 +511,7 @@ public class HBCIPassportDDV extends AbstractDDVPassport
                 } finally {
                     if (useSoftPin!=1) {
                         HBCIUtilsInternal.getCallback().callback(this,
-                                                         HBCICallback.Reason.HAVE_HARDPIN,
+                                                         Reason.HAVE_HARDPIN,
                                                          null,
                                                          ResponseType.NONE,
                                                          null);

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportDDVPCSC.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportDDVPCSC.java
@@ -74,10 +74,10 @@ public class HBCIPassportDDVPCSC extends HBCIPassportDDV
 
         try
         {
-          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),ResponseType.NONE,null);
+          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),ResponseType.NONE,null);
           HBCIUtils.log("initializing javax.smartcardio",HBCIUtils.LOG_DEBUG);
           this.initCT();
-          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.HAVE_CHIPCARD,"",ResponseType.NONE,null);
+          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.HAVE_CHIPCARD,"",ResponseType.NONE,null);
           
           this.ctReadBankData();
           

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportDDVPCSC.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportDDVPCSC.java
@@ -23,7 +23,7 @@ package org.kapott.hbci.passport;
 
 import java.io.File;
 
-import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.datatypes.SyntaxCtr;
 import org.kapott.hbci.exceptions.HBCI_Exception;
@@ -74,10 +74,10 @@ public class HBCIPassportDDVPCSC extends HBCIPassportDDV
 
         try
         {
-          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),ResponseType.NONE,null);
+          HBCIUtilsInternal.getCallback().callback(this,Reason.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),ResponseType.NONE,null);
           HBCIUtils.log("initializing javax.smartcardio",HBCIUtils.LOG_DEBUG);
           this.initCT();
-          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.Reason.HAVE_CHIPCARD,"",ResponseType.NONE,null);
+          HBCIUtilsInternal.getCallback().callback(this,Reason.HAVE_CHIPCARD,"",ResponseType.NONE,null);
           
           this.ctReadBankData();
           

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportDDVPCSC.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportDDVPCSC.java
@@ -24,6 +24,7 @@ package org.kapott.hbci.passport;
 import java.io.File;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.datatypes.SyntaxCtr;
 import org.kapott.hbci.exceptions.HBCI_Exception;
 import org.kapott.hbci.manager.HBCIKey;
@@ -73,10 +74,10 @@ public class HBCIPassportDDVPCSC extends HBCIPassportDDV
 
         try
         {
-          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),HBCICallback.ResponseType.NONE,null);
+          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),ResponseType.NONE,null);
           HBCIUtils.log("initializing javax.smartcardio",HBCIUtils.LOG_DEBUG);
           this.initCT();
-          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.HAVE_CHIPCARD,"",HBCICallback.ResponseType.NONE,null);
+          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.HAVE_CHIPCARD,"",ResponseType.NONE,null);
           
           this.ctReadBankData();
           

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportDDVPCSC.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportDDVPCSC.java
@@ -73,10 +73,10 @@ public class HBCIPassportDDVPCSC extends HBCIPassportDDV
 
         try
         {
-          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),HBCICallback.TYPE_NONE,null);
+          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),HBCICallback.ResponseType.TYPE_NONE,null);
           HBCIUtils.log("initializing javax.smartcardio",HBCIUtils.LOG_DEBUG);
           this.initCT();
-          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.HAVE_CHIPCARD,"",HBCICallback.TYPE_NONE,null);
+          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.HAVE_CHIPCARD,"",HBCICallback.ResponseType.TYPE_NONE,null);
           
           this.ctReadBankData();
           

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportDDVPCSC.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportDDVPCSC.java
@@ -73,10 +73,10 @@ public class HBCIPassportDDVPCSC extends HBCIPassportDDV
 
         try
         {
-          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),HBCICallback.ResponseType.TYPE_NONE,null);
+          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.NEED_CHIPCARD,HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"),HBCICallback.ResponseType.NONE,null);
           HBCIUtils.log("initializing javax.smartcardio",HBCIUtils.LOG_DEBUG);
           this.initCT();
-          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.HAVE_CHIPCARD,"",HBCICallback.ResponseType.TYPE_NONE,null);
+          HBCIUtilsInternal.getCallback().callback(this,HBCICallback.HAVE_CHIPCARD,"",HBCICallback.ResponseType.NONE,null);
           
           this.ctReadBankData();
           

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportPinTan.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportPinTan.java
@@ -263,7 +263,7 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                 HBCIUtilsInternal.getCallback().callback(this,
                                                  HBCICallback.NEED_PT_PIN,
                                                  HBCIUtilsInternal.getLocMsg("CALLB_NEED_PTPIN"),
-                                                 HBCICallback.ResponseType.TYPE_SECRET,
+                                                 HBCICallback.ResponseType.SECRET,
                                                  s);
                 if (s.length()==0) {
                     throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("EXCMSG_PINZERO"));
@@ -307,7 +307,7 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                                 HBCIUtilsInternal.getCallback().callback(this,
                                                 HBCICallback.NEED_PT_TAN,
                                                 HBCIUtilsInternal.getLocMsg("CALLB_NEED_PTTAN"),
-                                                HBCICallback.ResponseType.TYPE_TEXT,
+                                                HBCICallback.ResponseType.TEXT,
                                                 s);
                             }
                             catch (HBCI_Exception e)
@@ -400,7 +400,7 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                     }
 
                     // Callback durchfuehren
-                    HBCIUtilsInternal.getCallback().callback(this,callback,msg,HBCICallback.ResponseType.TYPE_TEXT,payload);
+                    HBCIUtilsInternal.getCallback().callback(this,callback,msg,HBCICallback.ResponseType.TEXT,payload);
 
                     setPersistentData("externalid",null); // External-ID aus Passport entfernen
                     if (payload == null || payload.length()==0) {

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportPinTan.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportPinTan.java
@@ -27,6 +27,7 @@ import java.util.Properties;
 import java.util.StringTokenizer;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.exceptions.HBCI_Exception;
 import org.kapott.hbci.manager.FlickerCode;
 import org.kapott.hbci.manager.HBCIUtils;
@@ -263,7 +264,7 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                 HBCIUtilsInternal.getCallback().callback(this,
                                                  HBCICallback.NEED_PT_PIN,
                                                  HBCIUtilsInternal.getLocMsg("CALLB_NEED_PTPIN"),
-                                                 HBCICallback.ResponseType.SECRET,
+                                                 ResponseType.SECRET,
                                                  s);
                 if (s.length()==0) {
                     throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("EXCMSG_PINZERO"));
@@ -307,7 +308,7 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                                 HBCIUtilsInternal.getCallback().callback(this,
                                                 HBCICallback.NEED_PT_TAN,
                                                 HBCIUtilsInternal.getLocMsg("CALLB_NEED_PTTAN"),
-                                                HBCICallback.ResponseType.TEXT,
+                                                ResponseType.TEXT,
                                                 s);
                             }
                             catch (HBCI_Exception e)
@@ -400,7 +401,7 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                     }
 
                     // Callback durchfuehren
-                    HBCIUtilsInternal.getCallback().callback(this,callback,msg,HBCICallback.ResponseType.TEXT,payload);
+                    HBCIUtilsInternal.getCallback().callback(this,callback,msg,ResponseType.TEXT,payload);
 
                     setPersistentData("externalid",null); // External-ID aus Passport entfernen
                     if (payload == null || payload.length()==0) {

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportPinTan.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportPinTan.java
@@ -262,7 +262,7 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                 StringBuffer s=new StringBuffer();
 
                 HBCIUtilsInternal.getCallback().callback(this,
-                                                 HBCICallback.NEED_PT_PIN,
+                                                 HBCICallback.Reason.NEED_PT_PIN,
                                                  HBCIUtilsInternal.getLocMsg("CALLB_NEED_PTPIN"),
                                                  ResponseType.SECRET,
                                                  s);
@@ -306,7 +306,7 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                             try
                             {
                                 HBCIUtilsInternal.getCallback().callback(this,
-                                                HBCICallback.NEED_PT_TAN,
+                                                HBCICallback.Reason.NEED_PT_TAN,
                                                 HBCIUtilsInternal.getLocMsg("CALLB_NEED_PTTAN"),
                                                 ResponseType.TEXT,
                                                 s);
@@ -371,7 +371,7 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                     final StringBuffer payload = new StringBuffer();
                     final String msg = secmechInfo.getProperty("name")+"\n"+secmechInfo.getProperty("inputinfo")+"\n\n"+challenge;
 
-                    int callback = HBCICallback.NEED_PT_TAN;
+                    HBCICallback.Reason callback = HBCICallback.Reason.NEED_PT_TAN;
 
                     // Um sicherzustellen, dass wird keinen falschen Callback ausloesen, weil wir die HHD-Version
                     // eventuell falsch erkannt haben, versuchen wir bei PhotoTAN und QR-Code zusaetzlich, die Daten
@@ -381,14 +381,14 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                         // Bei PhotoTAN haengen wir ungeparst das HHDuc an. Das kann dann auf
                         // Anwendungsseite per MatrixCode geparst werden
                         payload.append(hhduc);
-                        callback = HBCICallback.NEED_PT_PHOTOTAN;
+                        callback = HBCICallback.Reason.NEED_PT_PHOTOTAN;
                     }
                     else if (hhd.getType() == Type.QRCODE && (QRCode.tryParse(hhduc,msg) != null))
                     {
                         // Bei QR-Code haengen wir ungeparst das HHDuc an. Das kann dann auf
                         // Anwendungsseite per QRCode geparst werden
                         payload.append(hhduc);
-                        callback = HBCICallback.NEED_PT_QRTAN;
+                        callback = HBCICallback.Reason.NEED_PT_QRTAN;
                     }
                     else
                     {

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportPinTan.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportPinTan.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Properties;
 import java.util.StringTokenizer;
 
-import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.exceptions.HBCI_Exception;
 import org.kapott.hbci.manager.FlickerCode;
@@ -262,7 +262,7 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                 StringBuffer s=new StringBuffer();
 
                 HBCIUtilsInternal.getCallback().callback(this,
-                                                 HBCICallback.Reason.NEED_PT_PIN,
+                                                 Reason.NEED_PT_PIN,
                                                  HBCIUtilsInternal.getLocMsg("CALLB_NEED_PTPIN"),
                                                  ResponseType.SECRET,
                                                  s);
@@ -306,7 +306,7 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                             try
                             {
                                 HBCIUtilsInternal.getCallback().callback(this,
-                                                HBCICallback.Reason.NEED_PT_TAN,
+                                                Reason.NEED_PT_TAN,
                                                 HBCIUtilsInternal.getLocMsg("CALLB_NEED_PTTAN"),
                                                 ResponseType.TEXT,
                                                 s);
@@ -371,7 +371,7 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                     final StringBuffer payload = new StringBuffer();
                     final String msg = secmechInfo.getProperty("name")+"\n"+secmechInfo.getProperty("inputinfo")+"\n\n"+challenge;
 
-                    HBCICallback.Reason callback = HBCICallback.Reason.NEED_PT_TAN;
+                    Reason callback = Reason.NEED_PT_TAN;
 
                     // Um sicherzustellen, dass wird keinen falschen Callback ausloesen, weil wir die HHD-Version
                     // eventuell falsch erkannt haben, versuchen wir bei PhotoTAN und QR-Code zusaetzlich, die Daten
@@ -381,14 +381,14 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                         // Bei PhotoTAN haengen wir ungeparst das HHDuc an. Das kann dann auf
                         // Anwendungsseite per MatrixCode geparst werden
                         payload.append(hhduc);
-                        callback = HBCICallback.Reason.NEED_PT_PHOTOTAN;
+                        callback = Reason.NEED_PT_PHOTOTAN;
                     }
                     else if (hhd.getType() == Type.QRCODE && (QRCode.tryParse(hhduc,msg) != null))
                     {
                         // Bei QR-Code haengen wir ungeparst das HHDuc an. Das kann dann auf
                         // Anwendungsseite per QRCode geparst werden
                         payload.append(hhduc);
-                        callback = HBCICallback.Reason.NEED_PT_QRTAN;
+                        callback = Reason.NEED_PT_QRTAN;
                     }
                     else
                     {

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportPinTan.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportPinTan.java
@@ -263,7 +263,7 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                 HBCIUtilsInternal.getCallback().callback(this,
                                                  HBCICallback.NEED_PT_PIN,
                                                  HBCIUtilsInternal.getLocMsg("CALLB_NEED_PTPIN"),
-                                                 HBCICallback.TYPE_SECRET,
+                                                 HBCICallback.ResponseType.TYPE_SECRET,
                                                  s);
                 if (s.length()==0) {
                     throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("EXCMSG_PINZERO"));
@@ -307,7 +307,7 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                                 HBCIUtilsInternal.getCallback().callback(this,
                                                 HBCICallback.NEED_PT_TAN,
                                                 HBCIUtilsInternal.getLocMsg("CALLB_NEED_PTTAN"),
-                                                HBCICallback.TYPE_TEXT,
+                                                HBCICallback.ResponseType.TYPE_TEXT,
                                                 s);
                             }
                             catch (HBCI_Exception e)
@@ -400,7 +400,7 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
                     }
 
                     // Callback durchfuehren
-                    HBCIUtilsInternal.getCallback().callback(this,callback,msg,HBCICallback.TYPE_TEXT,payload);
+                    HBCIUtilsInternal.getCallback().callback(this,callback,msg,HBCICallback.ResponseType.TYPE_TEXT,payload);
 
                     setPersistentData("externalid",null); // External-ID aus Passport entfernen
                     if (payload == null || payload.length()==0) {

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportRDHXFile.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportRDHXFile.java
@@ -98,7 +98,7 @@ public class HBCIPassportRDHXFile
                     HBCIUtilsInternal.getCallback().callback(this,
                             HBCICallback.NEED_PASSPHRASE_LOAD,
                             HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
-                            HBCICallback.TYPE_SECRET,
+                            HBCICallback.ResponseType.TYPE_SECRET,
                             retData);
                     LogFilter.getInstance().addSecretData(retData.toString(),"X",LogFilter.FILTER_SECRETS);
                     setPassphrase(retData.toString().getBytes());
@@ -131,7 +131,7 @@ public class HBCIPassportRDHXFile
                         this,
                         HBCICallback.NEED_SIZENTRY_SELECT,
                         "*** select one of the following entries",
-                        HBCICallback.TYPE_TEXT,
+                        HBCICallback.ResponseType.TYPE_TEXT,
                         possibilities);
                      
                     this.entryIdx=Integer.parseInt(possibilities.toString());
@@ -190,7 +190,7 @@ public class HBCIPassportRDHXFile
                 HBCIUtilsInternal.getCallback().callback(this,
                         HBCICallback.NEED_PASSPHRASE_SAVE,
                         HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
-                        HBCICallback.TYPE_SECRET, retData);
+                        HBCICallback.ResponseType.TYPE_SECRET, retData);
                 // TODO: passwort-bedingungen nach spez. prüfen
                 LogFilter.getInstance().addSecretData(retData.toString(),"X",LogFilter.FILTER_SECRETS);
                 setPassphrase(retData.toString().getBytes());

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportRDHXFile.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportRDHXFile.java
@@ -28,6 +28,7 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.exceptions.HBCI_Exception;
 import org.kapott.hbci.manager.HBCIKey;
@@ -97,7 +98,7 @@ public class HBCIPassportRDHXFile
                 if (this.passphrase==null) {
                     StringBuffer retData=new StringBuffer();
                     HBCIUtilsInternal.getCallback().callback(this,
-                            HBCICallback.Reason.NEED_PASSPHRASE_LOAD,
+                            Reason.NEED_PASSPHRASE_LOAD,
                             HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
                             ResponseType.SECRET,
                             retData);
@@ -130,7 +131,7 @@ public class HBCIPassportRDHXFile
                     
                     HBCIUtilsInternal.getCallback().callback(
                         this,
-                        HBCICallback.Reason.NEED_SIZENTRY_SELECT,
+                        Reason.NEED_SIZENTRY_SELECT,
                         "*** select one of the following entries",
                         ResponseType.TEXT,
                         possibilities);
@@ -189,7 +190,7 @@ public class HBCIPassportRDHXFile
             if (this.passphrase == null) {
                 StringBuffer retData = new StringBuffer();
                 HBCIUtilsInternal.getCallback().callback(this,
-                        HBCICallback.Reason.NEED_PASSPHRASE_SAVE,
+                        Reason.NEED_PASSPHRASE_SAVE,
                         HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
                         ResponseType.SECRET, retData);
                 // TODO: passwort-bedingungen nach spez. prüfen

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportRDHXFile.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportRDHXFile.java
@@ -98,7 +98,7 @@ public class HBCIPassportRDHXFile
                     HBCIUtilsInternal.getCallback().callback(this,
                             HBCICallback.NEED_PASSPHRASE_LOAD,
                             HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
-                            HBCICallback.ResponseType.TYPE_SECRET,
+                            HBCICallback.ResponseType.SECRET,
                             retData);
                     LogFilter.getInstance().addSecretData(retData.toString(),"X",LogFilter.FILTER_SECRETS);
                     setPassphrase(retData.toString().getBytes());
@@ -131,7 +131,7 @@ public class HBCIPassportRDHXFile
                         this,
                         HBCICallback.NEED_SIZENTRY_SELECT,
                         "*** select one of the following entries",
-                        HBCICallback.ResponseType.TYPE_TEXT,
+                        HBCICallback.ResponseType.TEXT,
                         possibilities);
                      
                     this.entryIdx=Integer.parseInt(possibilities.toString());
@@ -190,7 +190,7 @@ public class HBCIPassportRDHXFile
                 HBCIUtilsInternal.getCallback().callback(this,
                         HBCICallback.NEED_PASSPHRASE_SAVE,
                         HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
-                        HBCICallback.ResponseType.TYPE_SECRET, retData);
+                        HBCICallback.ResponseType.SECRET, retData);
                 // TODO: passwort-bedingungen nach spez. prüfen
                 LogFilter.getInstance().addSecretData(retData.toString(),"X",LogFilter.FILTER_SECRETS);
                 setPassphrase(retData.toString().getBytes());

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportRDHXFile.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportRDHXFile.java
@@ -28,6 +28,7 @@ import java.io.FileOutputStream;
 import java.io.InputStream;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.exceptions.HBCI_Exception;
 import org.kapott.hbci.manager.HBCIKey;
 import org.kapott.hbci.manager.HBCIUtils;
@@ -98,7 +99,7 @@ public class HBCIPassportRDHXFile
                     HBCIUtilsInternal.getCallback().callback(this,
                             HBCICallback.NEED_PASSPHRASE_LOAD,
                             HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
-                            HBCICallback.ResponseType.SECRET,
+                            ResponseType.SECRET,
                             retData);
                     LogFilter.getInstance().addSecretData(retData.toString(),"X",LogFilter.FILTER_SECRETS);
                     setPassphrase(retData.toString().getBytes());
@@ -131,7 +132,7 @@ public class HBCIPassportRDHXFile
                         this,
                         HBCICallback.NEED_SIZENTRY_SELECT,
                         "*** select one of the following entries",
-                        HBCICallback.ResponseType.TEXT,
+                        ResponseType.TEXT,
                         possibilities);
                      
                     this.entryIdx=Integer.parseInt(possibilities.toString());
@@ -190,7 +191,7 @@ public class HBCIPassportRDHXFile
                 HBCIUtilsInternal.getCallback().callback(this,
                         HBCICallback.NEED_PASSPHRASE_SAVE,
                         HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
-                        HBCICallback.ResponseType.SECRET, retData);
+                        ResponseType.SECRET, retData);
                 // TODO: passwort-bedingungen nach spez. prüfen
                 LogFilter.getInstance().addSecretData(retData.toString(),"X",LogFilter.FILTER_SECRETS);
                 setPassphrase(retData.toString().getBytes());

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportRDHXFile.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportRDHXFile.java
@@ -97,7 +97,7 @@ public class HBCIPassportRDHXFile
                 if (this.passphrase==null) {
                     StringBuffer retData=new StringBuffer();
                     HBCIUtilsInternal.getCallback().callback(this,
-                            HBCICallback.NEED_PASSPHRASE_LOAD,
+                            HBCICallback.Reason.NEED_PASSPHRASE_LOAD,
                             HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
                             ResponseType.SECRET,
                             retData);
@@ -130,7 +130,7 @@ public class HBCIPassportRDHXFile
                     
                     HBCIUtilsInternal.getCallback().callback(
                         this,
-                        HBCICallback.NEED_SIZENTRY_SELECT,
+                        HBCICallback.Reason.NEED_SIZENTRY_SELECT,
                         "*** select one of the following entries",
                         ResponseType.TEXT,
                         possibilities);
@@ -189,7 +189,7 @@ public class HBCIPassportRDHXFile
             if (this.passphrase == null) {
                 StringBuffer retData = new StringBuffer();
                 HBCIUtilsInternal.getCallback().callback(this,
-                        HBCICallback.NEED_PASSPHRASE_SAVE,
+                        HBCICallback.Reason.NEED_PASSPHRASE_SAVE,
                         HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
                         ResponseType.SECRET, retData);
                 // TODO: passwort-bedingungen nach spez. prüfen

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportRSA.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportRSA.java
@@ -16,6 +16,7 @@ import java.util.Arrays;
 
 import org.kapott.cryptalgs.SignatureParamSpec;
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.datatypes.SyntaxCtr;
 import org.kapott.hbci.exceptions.HBCI_Exception;
 import org.kapott.hbci.manager.HBCIKey;
@@ -96,10 +97,10 @@ public class HBCIPassportRSA extends AbstractRDHPassport implements HBCIPassport
             ////////////////////////////////////////////////////////////////////////
             // init card
             HBCIUtils.log("initializing javax.smartcardio", HBCIUtils.LOG_DEBUG);
-            HBCIUtilsInternal.getCallback().callback(this, HBCICallback.NEED_CHIPCARD, HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"), HBCICallback.ResponseType.NONE, null);
+            HBCIUtilsInternal.getCallback().callback(this, HBCICallback.NEED_CHIPCARD, HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"), ResponseType.NONE, null);
             
             initCT();
-            HBCIUtilsInternal.getCallback().callback(this, HBCICallback.HAVE_CHIPCARD, "", HBCICallback.ResponseType.NONE, null);
+            HBCIUtilsInternal.getCallback().callback(this, HBCICallback.HAVE_CHIPCARD, "", ResponseType.NONE, null);
             //
             ////////////////////////////////////////////////////////////////////////
             
@@ -901,7 +902,7 @@ public class HBCIPassportRSA extends AbstractRDHPassport implements HBCIPassport
                         HBCIUtilsInternal.getCallback().callback(this,
                                                          HBCICallback.NEED_SOFTPIN,
                                                          HBCIUtilsInternal.getLocMsg("CALLB_NEED_SOFTPIN"),
-                                                         HBCICallback.ResponseType.SECRET,
+                                                         ResponseType.SECRET,
                                                          temppin);
                         if (temppin.length() == 0)
                             throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("EXCMSG_PINZERO"));
@@ -914,7 +915,7 @@ public class HBCIPassportRSA extends AbstractRDHPassport implements HBCIPassport
                     HBCIUtilsInternal.getCallback().callback(this,
                                                      HBCICallback.NEED_HARDPIN,
                                                      HBCIUtilsInternal.getLocMsg("CALLB_NEED_HARDPIN"),
-                                                     HBCICallback.ResponseType.NONE,
+                                                     ResponseType.NONE,
                                                      null);
                 }
 
@@ -929,7 +930,7 @@ public class HBCIPassportRSA extends AbstractRDHPassport implements HBCIPassport
                         HBCIUtilsInternal.getCallback().callback(this,
                                                          HBCICallback.HAVE_HARDPIN,
                                                          null,
-                                                         HBCICallback.ResponseType.NONE,
+                                                         ResponseType.NONE,
                                                          null);
                     }
                 }

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportRSA.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportRSA.java
@@ -97,10 +97,10 @@ public class HBCIPassportRSA extends AbstractRDHPassport implements HBCIPassport
             ////////////////////////////////////////////////////////////////////////
             // init card
             HBCIUtils.log("initializing javax.smartcardio", HBCIUtils.LOG_DEBUG);
-            HBCIUtilsInternal.getCallback().callback(this, HBCICallback.NEED_CHIPCARD, HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"), ResponseType.NONE, null);
+            HBCIUtilsInternal.getCallback().callback(this, HBCICallback.Reason.NEED_CHIPCARD, HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"), ResponseType.NONE, null);
             
             initCT();
-            HBCIUtilsInternal.getCallback().callback(this, HBCICallback.HAVE_CHIPCARD, "", ResponseType.NONE, null);
+            HBCIUtilsInternal.getCallback().callback(this, HBCICallback.Reason.HAVE_CHIPCARD, "", ResponseType.NONE, null);
             //
             ////////////////////////////////////////////////////////////////////////
             
@@ -900,7 +900,7 @@ public class HBCIPassportRSA extends AbstractRDHPassport implements HBCIPassport
                     if (pin == null || pin.length() == 0) {
                         StringBuffer temppin = new StringBuffer();
                         HBCIUtilsInternal.getCallback().callback(this,
-                                                         HBCICallback.NEED_SOFTPIN,
+                                                         HBCICallback.Reason.NEED_SOFTPIN,
                                                          HBCIUtilsInternal.getLocMsg("CALLB_NEED_SOFTPIN"),
                                                          ResponseType.SECRET,
                                                          temppin);
@@ -913,7 +913,7 @@ public class HBCIPassportRSA extends AbstractRDHPassport implements HBCIPassport
                     setSoftPin(pin.getBytes("ISO-8859-1"));
                 } else {
                     HBCIUtilsInternal.getCallback().callback(this,
-                                                     HBCICallback.NEED_HARDPIN,
+                                                     HBCICallback.Reason.NEED_HARDPIN,
                                                      HBCIUtilsInternal.getLocMsg("CALLB_NEED_HARDPIN"),
                                                      ResponseType.NONE,
                                                      null);
@@ -928,7 +928,7 @@ public class HBCIPassportRSA extends AbstractRDHPassport implements HBCIPassport
                 } finally {
                     if (getUseSoftPin() != 1) {
                         HBCIUtilsInternal.getCallback().callback(this,
-                                                         HBCICallback.HAVE_HARDPIN,
+                                                         HBCICallback.Reason.HAVE_HARDPIN,
                                                          null,
                                                          ResponseType.NONE,
                                                          null);

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportRSA.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportRSA.java
@@ -96,10 +96,10 @@ public class HBCIPassportRSA extends AbstractRDHPassport implements HBCIPassport
             ////////////////////////////////////////////////////////////////////////
             // init card
             HBCIUtils.log("initializing javax.smartcardio", HBCIUtils.LOG_DEBUG);
-            HBCIUtilsInternal.getCallback().callback(this, HBCICallback.NEED_CHIPCARD, HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"), HBCICallback.ResponseType.TYPE_NONE, null);
+            HBCIUtilsInternal.getCallback().callback(this, HBCICallback.NEED_CHIPCARD, HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"), HBCICallback.ResponseType.NONE, null);
             
             initCT();
-            HBCIUtilsInternal.getCallback().callback(this, HBCICallback.HAVE_CHIPCARD, "", HBCICallback.ResponseType.TYPE_NONE, null);
+            HBCIUtilsInternal.getCallback().callback(this, HBCICallback.HAVE_CHIPCARD, "", HBCICallback.ResponseType.NONE, null);
             //
             ////////////////////////////////////////////////////////////////////////
             
@@ -901,7 +901,7 @@ public class HBCIPassportRSA extends AbstractRDHPassport implements HBCIPassport
                         HBCIUtilsInternal.getCallback().callback(this,
                                                          HBCICallback.NEED_SOFTPIN,
                                                          HBCIUtilsInternal.getLocMsg("CALLB_NEED_SOFTPIN"),
-                                                         HBCICallback.ResponseType.TYPE_SECRET,
+                                                         HBCICallback.ResponseType.SECRET,
                                                          temppin);
                         if (temppin.length() == 0)
                             throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("EXCMSG_PINZERO"));
@@ -914,7 +914,7 @@ public class HBCIPassportRSA extends AbstractRDHPassport implements HBCIPassport
                     HBCIUtilsInternal.getCallback().callback(this,
                                                      HBCICallback.NEED_HARDPIN,
                                                      HBCIUtilsInternal.getLocMsg("CALLB_NEED_HARDPIN"),
-                                                     HBCICallback.ResponseType.TYPE_NONE,
+                                                     HBCICallback.ResponseType.NONE,
                                                      null);
                 }
 
@@ -929,7 +929,7 @@ public class HBCIPassportRSA extends AbstractRDHPassport implements HBCIPassport
                         HBCIUtilsInternal.getCallback().callback(this,
                                                          HBCICallback.HAVE_HARDPIN,
                                                          null,
-                                                         HBCICallback.ResponseType.TYPE_NONE,
+                                                         HBCICallback.ResponseType.NONE,
                                                          null);
                     }
                 }

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportRSA.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportRSA.java
@@ -3,17 +3,16 @@
  */
 package org.kapott.hbci.passport;
 
-import java.io.File;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.security.NoSuchProviderException;
-import java.util.Arrays;
-
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.DESedeKeySpec;
 import javax.crypto.spec.IvParameterSpec;
+import java.io.File;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.NoSuchProviderException;
+import java.util.Arrays;
 
 import org.kapott.cryptalgs.SignatureParamSpec;
 import org.kapott.hbci.callback.HBCICallback;
@@ -97,10 +96,10 @@ public class HBCIPassportRSA extends AbstractRDHPassport implements HBCIPassport
             ////////////////////////////////////////////////////////////////////////
             // init card
             HBCIUtils.log("initializing javax.smartcardio", HBCIUtils.LOG_DEBUG);
-            HBCIUtilsInternal.getCallback().callback(this, HBCICallback.NEED_CHIPCARD, HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"), HBCICallback.TYPE_NONE, null);
+            HBCIUtilsInternal.getCallback().callback(this, HBCICallback.NEED_CHIPCARD, HBCIUtilsInternal.getLocMsg("CALLB_NEED_CHIPCARD"), HBCICallback.ResponseType.TYPE_NONE, null);
             
             initCT();
-            HBCIUtilsInternal.getCallback().callback(this, HBCICallback.HAVE_CHIPCARD, "", HBCICallback.TYPE_NONE, null);
+            HBCIUtilsInternal.getCallback().callback(this, HBCICallback.HAVE_CHIPCARD, "", HBCICallback.ResponseType.TYPE_NONE, null);
             //
             ////////////////////////////////////////////////////////////////////////
             
@@ -902,7 +901,7 @@ public class HBCIPassportRSA extends AbstractRDHPassport implements HBCIPassport
                         HBCIUtilsInternal.getCallback().callback(this,
                                                          HBCICallback.NEED_SOFTPIN,
                                                          HBCIUtilsInternal.getLocMsg("CALLB_NEED_SOFTPIN"),
-                                                         HBCICallback.TYPE_SECRET,
+                                                         HBCICallback.ResponseType.TYPE_SECRET,
                                                          temppin);
                         if (temppin.length() == 0)
                             throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("EXCMSG_PINZERO"));
@@ -915,7 +914,7 @@ public class HBCIPassportRSA extends AbstractRDHPassport implements HBCIPassport
                     HBCIUtilsInternal.getCallback().callback(this,
                                                      HBCICallback.NEED_HARDPIN,
                                                      HBCIUtilsInternal.getLocMsg("CALLB_NEED_HARDPIN"),
-                                                     HBCICallback.TYPE_NONE,
+                                                     HBCICallback.ResponseType.TYPE_NONE,
                                                      null);
                 }
 
@@ -930,7 +929,7 @@ public class HBCIPassportRSA extends AbstractRDHPassport implements HBCIPassport
                         HBCIUtilsInternal.getCallback().callback(this,
                                                          HBCICallback.HAVE_HARDPIN,
                                                          null,
-                                                         HBCICallback.TYPE_NONE,
+                                                         HBCICallback.ResponseType.TYPE_NONE,
                                                          null);
                     }
                 }

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportSIZRDHFile.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportSIZRDHFile.java
@@ -97,7 +97,7 @@ public class HBCIPassportSIZRDHFile
                     HBCIUtilsInternal.getCallback().callback(this,
                                                      HBCICallback.NEED_PASSPHRASE_LOAD,
                                                      HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
-                                                     HBCICallback.TYPE_SECRET,
+                                                     HBCICallback.ResponseType.TYPE_SECRET,
                                                      retData);
                     LogFilter.getInstance().addSecretData(retData.toString(),"X",LogFilter.FILTER_SECRETS);
                     setPassphrase(retData.toString());
@@ -158,7 +158,7 @@ public class HBCIPassportSIZRDHFile
         HBCIUtilsInternal.getCallback().callback(this,
                                          HBCICallback.NEED_SIZENTRY_SELECT,
                                          "*** select one of the following entries",
-                                         HBCICallback.TYPE_TEXT,
+                                         HBCICallback.ResponseType.TYPE_TEXT,
                                          sb);
         return Integer.parseInt(sb.toString());
     }

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportSIZRDHFile.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportSIZRDHFile.java
@@ -24,6 +24,7 @@ package org.kapott.hbci.passport;
 import java.io.File;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.exceptions.HBCI_Exception;
 import org.kapott.hbci.manager.HBCIUtils;
 import org.kapott.hbci.manager.HBCIUtilsInternal;
@@ -97,7 +98,7 @@ public class HBCIPassportSIZRDHFile
                     HBCIUtilsInternal.getCallback().callback(this,
                                                      HBCICallback.NEED_PASSPHRASE_LOAD,
                                                      HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
-                                                     HBCICallback.ResponseType.SECRET,
+                                                     ResponseType.SECRET,
                                                      retData);
                     LogFilter.getInstance().addSecretData(retData.toString(),"X",LogFilter.FILTER_SECRETS);
                     setPassphrase(retData.toString());
@@ -158,7 +159,7 @@ public class HBCIPassportSIZRDHFile
         HBCIUtilsInternal.getCallback().callback(this,
                                          HBCICallback.NEED_SIZENTRY_SELECT,
                                          "*** select one of the following entries",
-                                         HBCICallback.ResponseType.TEXT,
+                                         ResponseType.TEXT,
                                          sb);
         return Integer.parseInt(sb.toString());
     }

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportSIZRDHFile.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportSIZRDHFile.java
@@ -97,7 +97,7 @@ public class HBCIPassportSIZRDHFile
                     HBCIUtilsInternal.getCallback().callback(this,
                                                      HBCICallback.NEED_PASSPHRASE_LOAD,
                                                      HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
-                                                     HBCICallback.ResponseType.TYPE_SECRET,
+                                                     HBCICallback.ResponseType.SECRET,
                                                      retData);
                     LogFilter.getInstance().addSecretData(retData.toString(),"X",LogFilter.FILTER_SECRETS);
                     setPassphrase(retData.toString());
@@ -158,7 +158,7 @@ public class HBCIPassportSIZRDHFile
         HBCIUtilsInternal.getCallback().callback(this,
                                          HBCICallback.NEED_SIZENTRY_SELECT,
                                          "*** select one of the following entries",
-                                         HBCICallback.ResponseType.TYPE_TEXT,
+                                         HBCICallback.ResponseType.TEXT,
                                          sb);
         return Integer.parseInt(sb.toString());
     }

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportSIZRDHFile.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportSIZRDHFile.java
@@ -24,6 +24,7 @@ package org.kapott.hbci.passport;
 import java.io.File;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.exceptions.HBCI_Exception;
 import org.kapott.hbci.manager.HBCIUtils;
@@ -96,7 +97,7 @@ public class HBCIPassportSIZRDHFile
                 if (passphrase==null) {
                     StringBuffer retData=new StringBuffer();
                     HBCIUtilsInternal.getCallback().callback(this,
-                                                     HBCICallback.Reason.NEED_PASSPHRASE_LOAD,
+                                                     Reason.NEED_PASSPHRASE_LOAD,
                                                      HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
                                                      ResponseType.SECRET,
                                                      retData);
@@ -157,7 +158,7 @@ public class HBCIPassportSIZRDHFile
     {
         StringBuffer sb=new StringBuffer(possibilities);
         HBCIUtilsInternal.getCallback().callback(this,
-                                         HBCICallback.Reason.NEED_SIZENTRY_SELECT,
+                                         Reason.NEED_SIZENTRY_SELECT,
                                          "*** select one of the following entries",
                                          ResponseType.TEXT,
                                          sb);

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportSIZRDHFile.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportSIZRDHFile.java
@@ -96,7 +96,7 @@ public class HBCIPassportSIZRDHFile
                 if (passphrase==null) {
                     StringBuffer retData=new StringBuffer();
                     HBCIUtilsInternal.getCallback().callback(this,
-                                                     HBCICallback.NEED_PASSPHRASE_LOAD,
+                                                     HBCICallback.Reason.NEED_PASSPHRASE_LOAD,
                                                      HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
                                                      ResponseType.SECRET,
                                                      retData);
@@ -157,7 +157,7 @@ public class HBCIPassportSIZRDHFile
     {
         StringBuffer sb=new StringBuffer(possibilities);
         HBCIUtilsInternal.getCallback().callback(this,
-                                         HBCICallback.NEED_SIZENTRY_SELECT,
+                                         HBCICallback.Reason.NEED_SIZENTRY_SELECT,
                                          "*** select one of the following entries",
                                          ResponseType.TEXT,
                                          sb);

--- a/src/main/java/org/kapott/hbci/passport/storage/format/AbstractFormat.java
+++ b/src/main/java/org/kapott/hbci/passport/storage/format/AbstractFormat.java
@@ -103,7 +103,7 @@ public abstract class AbstractFormat implements PassportFormat
         
         StringBuffer passphrase = new StringBuffer();
         HBCIUtilsInternal.getCallback().callback(passport,
-                                         forSaving ? HBCICallback.NEED_PASSPHRASE_SAVE : HBCICallback.NEED_PASSPHRASE_LOAD,
+                                         forSaving ? HBCICallback.Reason.NEED_PASSPHRASE_SAVE : HBCICallback.Reason.NEED_PASSPHRASE_LOAD,
                                          forSaving ? HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS_NEW") : HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
                                          ResponseType.SECRET,
                                          passphrase);

--- a/src/main/java/org/kapott/hbci/passport/storage/format/AbstractFormat.java
+++ b/src/main/java/org/kapott/hbci/passport/storage/format/AbstractFormat.java
@@ -104,7 +104,7 @@ public abstract class AbstractFormat implements PassportFormat
         HBCIUtilsInternal.getCallback().callback(passport,
                                          forSaving ? HBCICallback.NEED_PASSPHRASE_SAVE : HBCICallback.NEED_PASSPHRASE_LOAD,
                                          forSaving ? HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS_NEW") : HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
-                                         HBCICallback.ResponseType.TYPE_SECRET,
+                                         HBCICallback.ResponseType.SECRET,
                                          passphrase);
         if (passphrase.length() == 0)
             throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_PASSZERO"));

--- a/src/main/java/org/kapott/hbci/passport/storage/format/AbstractFormat.java
+++ b/src/main/java/org/kapott/hbci/passport/storage/format/AbstractFormat.java
@@ -21,9 +21,8 @@
 
 package org.kapott.hbci.passport.storage.format;
 
-import java.security.GeneralSecurityException;
-
 import javax.crypto.Cipher;
+import java.security.GeneralSecurityException;
 
 import org.kapott.hbci.callback.HBCICallback;
 import org.kapott.hbci.exceptions.InvalidUserDataException;
@@ -105,7 +104,7 @@ public abstract class AbstractFormat implements PassportFormat
         HBCIUtilsInternal.getCallback().callback(passport,
                                          forSaving ? HBCICallback.NEED_PASSPHRASE_SAVE : HBCICallback.NEED_PASSPHRASE_LOAD,
                                          forSaving ? HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS_NEW") : HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
-                                         HBCICallback.TYPE_SECRET,
+                                         HBCICallback.ResponseType.TYPE_SECRET,
                                          passphrase);
         if (passphrase.length() == 0)
             throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_PASSZERO"));

--- a/src/main/java/org/kapott/hbci/passport/storage/format/AbstractFormat.java
+++ b/src/main/java/org/kapott/hbci/passport/storage/format/AbstractFormat.java
@@ -25,6 +25,7 @@ import javax.crypto.Cipher;
 import java.security.GeneralSecurityException;
 
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.exceptions.InvalidUserDataException;
 import org.kapott.hbci.manager.HBCIUtils;
 import org.kapott.hbci.manager.HBCIUtilsInternal;
@@ -104,7 +105,7 @@ public abstract class AbstractFormat implements PassportFormat
         HBCIUtilsInternal.getCallback().callback(passport,
                                          forSaving ? HBCICallback.NEED_PASSPHRASE_SAVE : HBCICallback.NEED_PASSPHRASE_LOAD,
                                          forSaving ? HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS_NEW") : HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
-                                         HBCICallback.ResponseType.SECRET,
+                                         ResponseType.SECRET,
                                          passphrase);
         if (passphrase.length() == 0)
             throw new InvalidUserDataException(HBCIUtilsInternal.getLocMsg("EXCMSG_PASSZERO"));

--- a/src/main/java/org/kapott/hbci/passport/storage/format/AbstractFormat.java
+++ b/src/main/java/org/kapott/hbci/passport/storage/format/AbstractFormat.java
@@ -24,7 +24,7 @@ package org.kapott.hbci.passport.storage.format;
 import javax.crypto.Cipher;
 import java.security.GeneralSecurityException;
 
-import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallback.ResponseType;
 import org.kapott.hbci.exceptions.InvalidUserDataException;
 import org.kapott.hbci.manager.HBCIUtils;
@@ -103,7 +103,7 @@ public abstract class AbstractFormat implements PassportFormat
         
         StringBuffer passphrase = new StringBuffer();
         HBCIUtilsInternal.getCallback().callback(passport,
-                                         forSaving ? HBCICallback.Reason.NEED_PASSPHRASE_SAVE : HBCICallback.Reason.NEED_PASSPHRASE_LOAD,
+                                         forSaving ? Reason.NEED_PASSPHRASE_SAVE : Reason.NEED_PASSPHRASE_LOAD,
                                          forSaving ? HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS_NEW") : HBCIUtilsInternal.getLocMsg("CALLB_NEED_PASS"),
                                          ResponseType.SECRET,
                                          passphrase);

--- a/src/main/java/org/kapott/hbci/tools/AnalyzeReportOfTransactions.java
+++ b/src/main/java/org/kapott/hbci/tools/AnalyzeReportOfTransactions.java
@@ -96,7 +96,7 @@ public final class AnalyzeReportOfTransactions
     private static class MyHBCICallback
         extends HBCICallbackConsole
     {
-        public void callback(HBCIPassport passport,int reason,String msg,int dataType,StringBuffer retData)
+        public void callback(HBCIPassport passport,int reason,String msg,ResponseType dataType,StringBuffer retData)
         {
             System.out.println("Callback für folgendes Passport: "+passport.getClientData("init").toString());
             super.callback(passport,reason,msg,dataType,retData);

--- a/src/main/java/org/kapott/hbci/tools/AnalyzeReportOfTransactions.java
+++ b/src/main/java/org/kapott/hbci/tools/AnalyzeReportOfTransactions.java
@@ -96,7 +96,7 @@ public final class AnalyzeReportOfTransactions
     private static class MyHBCICallback
         extends HBCICallbackConsole
     {
-        public void callback(HBCIPassport passport,int reason,String msg,ResponseType dataType,StringBuffer retData)
+        public void callback(HBCIPassport passport,Reason reason,String msg,ResponseType dataType,StringBuffer retData)
         {
             System.out.println("Callback für folgendes Passport: "+passport.getClientData("init").toString());
             super.callback(passport,reason,msg,dataType,retData);

--- a/src/main/java/org/kapott/hbci/tools/CollectHashCodes.java
+++ b/src/main/java/org/kapott/hbci/tools/CollectHashCodes.java
@@ -41,7 +41,7 @@ public class CollectHashCodes
     private static class MyCallback 
         extends HBCICallbackConsole
     {
-        public void callback(HBCIPassport passport,int reason,String msg,
+        public void callback(HBCIPassport passport,Reason reason,String msg,
                              int datatype,StringBuffer retData)
         {
             Properties data=(Properties)passport.getClientData("init");

--- a/src/main/java/org/kapott/hbci/tools/DepotAbrufTest.java
+++ b/src/main/java/org/kapott/hbci/tools/DepotAbrufTest.java
@@ -115,7 +115,7 @@ public final class DepotAbrufTest
     private static class MyHBCICallback
         extends HBCICallbackConsole
     {
-        public void callback(HBCIPassport passport,int reason,String msg,int dataType,StringBuffer retData)
+        public void callback(HBCIPassport passport,int reason,String msg,ResponseType dataType,StringBuffer retData)
         {
             if (reason == HBCICallback.CLOSE_CONNECTION || reason == HBCICallback.NEED_CONNECTION)
                 return;

--- a/src/main/java/org/kapott/hbci/tools/DepotAbrufTest.java
+++ b/src/main/java/org/kapott/hbci/tools/DepotAbrufTest.java
@@ -115,9 +115,9 @@ public final class DepotAbrufTest
     private static class MyHBCICallback
         extends HBCICallbackConsole
     {
-        public void callback(HBCIPassport passport,int reason,String msg,ResponseType dataType,StringBuffer retData)
+        public void callback(HBCIPassport passport,Reason reason,String msg,ResponseType dataType,StringBuffer retData)
         {
-            if (reason == HBCICallback.CLOSE_CONNECTION || reason == HBCICallback.NEED_CONNECTION)
+            if (reason == HBCICallback.Reason.CLOSE_CONNECTION || reason == HBCICallback.Reason.NEED_CONNECTION)
                 return;
             
             System.out.println("Callback für folgendes Passport: "+passport.getClientData("init").toString() + ", reason=" + reason);

--- a/src/main/java/org/kapott/hbci/tools/HBCIBatch.java
+++ b/src/main/java/org/kapott/hbci/tools/HBCIBatch.java
@@ -166,7 +166,7 @@ public class HBCIBatch {
 
         // modifizierte callback-methode, die daten-anfragen "automatisch"
         // beantwortet
-        public synchronized void callback(HBCIPassport passport, int reason, String msg, int datatype,
+        public synchronized void callback(HBCIPassport passport, Reason reason, String msg, ResponseType datatype,
                 StringBuffer retData) {
             switch (reason) {
             case NEED_CHIPCARD:

--- a/src/main/java/org/kapott/hbci/tools/InitAndTest.java
+++ b/src/main/java/org/kapott/hbci/tools/InitAndTest.java
@@ -64,7 +64,7 @@ public final class InitAndTest
         extends HBCICallbackConsole
     {
         @Override
-        public synchronized void status(HBCIPassport passport, int statusTag,
+        public synchronized void status(HBCIPassport passport, Status statusTag,
                                         Object[] o)
         {
             // disable status output

--- a/src/test/java/org/kapott/hbci4java/AbstractTestGV.java
+++ b/src/test/java/org/kapott/hbci4java/AbstractTestGV.java
@@ -21,6 +21,7 @@ import org.junit.BeforeClass;
 import org.kapott.hbci.GV.HBCIJob;
 import org.kapott.hbci.GV_Result.HBCIJobResult;
 import org.kapott.hbci.callback.HBCICallback;
+import org.kapott.hbci.callback.HBCICallback.Reason;
 import org.kapott.hbci.callback.HBCICallbackIOStreams;
 import org.kapott.hbci.manager.BankInfo;
 import org.kapott.hbci.manager.HBCIHandler;
@@ -36,7 +37,7 @@ import org.kapott.hbci.status.HBCIExecStatus;
  */
 public abstract class AbstractTestGV
 {
-    private final Map<HBCICallback.Reason,String> callbackValues = new HashMap<>();
+    private final Map<Reason,String> callbackValues = new HashMap<>();
     private Properties  params          = null;
     private HBCIPassportPinTan passport = null;
     private HBCIHandler handler         = null;
@@ -89,22 +90,22 @@ public abstract class AbstractTestGV
         }
       
         // Presets fuer den Callback
-        this.callbackValues.put(HBCICallback.Reason.NEED_COUNTRY,          params.getProperty("country",System.getProperty("country","DE")));
-        this.callbackValues.put(HBCICallback.Reason.NEED_CUSTOMERID,       params.getProperty("customerid",System.getProperty("customerid","")));
-        this.callbackValues.put(HBCICallback.Reason.NEED_USERID,           params.getProperty("userid",System.getProperty("userid","")));
-        this.callbackValues.put(HBCICallback.Reason.NEED_PT_PIN,           params.getProperty("pin",System.getProperty("pin","")));
-        this.callbackValues.put(HBCICallback.Reason.NEED_PT_SECMECH,       params.getProperty("secmech",System.getProperty("secmech","")));
+        this.callbackValues.put(Reason.NEED_COUNTRY,         params.getProperty("country", System.getProperty("country", "DE")));
+        this.callbackValues.put(Reason.NEED_CUSTOMERID,      params.getProperty("customerid", System.getProperty("customerid", "")));
+        this.callbackValues.put(Reason.NEED_USERID,          params.getProperty("userid", System.getProperty("userid", "")));
+        this.callbackValues.put(Reason.NEED_PT_PIN,          params.getProperty("pin", System.getProperty("pin", "")));
+        this.callbackValues.put(Reason.NEED_PT_SECMECH,      params.getProperty("secmech", System.getProperty("secmech", "")));
 
         // Das Passport-Passwort
-        this.callbackValues.put(HBCICallback.Reason.NEED_PASSPHRASE_LOAD,  params.getProperty("password",System.getProperty("password","")));
-        this.callbackValues.put(HBCICallback.Reason.NEED_PASSPHRASE_SAVE,  params.getProperty("password",System.getProperty("password","")));
+        this.callbackValues.put(Reason.NEED_PASSPHRASE_LOAD, params.getProperty("password", System.getProperty("password", "")));
+        this.callbackValues.put(Reason.NEED_PASSPHRASE_SAVE, params.getProperty("password", System.getProperty("password", "")));
 
         final String blz = params.getProperty("blz",System.getProperty("blz"));
-        this.callbackValues.put(HBCICallback.Reason.NEED_BLZ,              blz);
-        this.callbackValues.put(HBCICallback.Reason.NEED_PORT,             params.getProperty("port",System.getProperty("port","443")));
-        this.callbackValues.put(HBCICallback.Reason.NEED_FILTER,           params.getProperty("filter",System.getProperty("filter","Base64")));
-        this.callbackValues.put(HBCICallback.Reason.NEED_CONNECTION,       "");
-        this.callbackValues.put(HBCICallback.Reason.CLOSE_CONNECTION,      "");
+        this.callbackValues.put(Reason.NEED_BLZ,             blz);
+        this.callbackValues.put(Reason.NEED_PORT,            params.getProperty("port", System.getProperty("port", "443")));
+        this.callbackValues.put(Reason.NEED_FILTER,          params.getProperty("filter", System.getProperty("filter", "Base64")));
+        this.callbackValues.put(Reason.NEED_CONNECTION,      "");
+        this.callbackValues.put(Reason.CLOSE_CONNECTION,     "");
 
               
         // Initialisierungsparameter fuer HBCI4Java selbst
@@ -173,7 +174,7 @@ public abstract class AbstractTestGV
             if (bank != null)
                 host = bank.getPinTanAddress();
         }
-        this.callbackValues.put(HBCICallback.Reason.NEED_HOST,host);
+        this.callbackValues.put(Reason.NEED_HOST, host);
         //
         ////////////////////////////////////////////////////////////////////////
 

--- a/src/test/java/org/kapott/hbci4java/AbstractTestGV.java
+++ b/src/test/java/org/kapott/hbci4java/AbstractTestGV.java
@@ -36,7 +36,7 @@ import org.kapott.hbci.status.HBCIExecStatus;
  */
 public abstract class AbstractTestGV
 {
-    private final Map<Integer,String> callbackValues = new HashMap<Integer,String>();
+    private final Map<HBCICallback.Reason,String> callbackValues = new HashMap<>();
     private Properties  params          = null;
     private HBCIPassportPinTan passport = null;
     private HBCIHandler handler         = null;
@@ -89,22 +89,22 @@ public abstract class AbstractTestGV
         }
       
         // Presets fuer den Callback
-        this.callbackValues.put(HBCICallback.NEED_COUNTRY,          params.getProperty("country",System.getProperty("country","DE")));
-        this.callbackValues.put(HBCICallback.NEED_CUSTOMERID,       params.getProperty("customerid",System.getProperty("customerid","")));
-        this.callbackValues.put(HBCICallback.NEED_USERID,           params.getProperty("userid",System.getProperty("userid","")));
-        this.callbackValues.put(HBCICallback.NEED_PT_PIN,           params.getProperty("pin",System.getProperty("pin","")));
-        this.callbackValues.put(HBCICallback.NEED_PT_SECMECH,       params.getProperty("secmech",System.getProperty("secmech","")));
+        this.callbackValues.put(HBCICallback.Reason.NEED_COUNTRY,          params.getProperty("country",System.getProperty("country","DE")));
+        this.callbackValues.put(HBCICallback.Reason.NEED_CUSTOMERID,       params.getProperty("customerid",System.getProperty("customerid","")));
+        this.callbackValues.put(HBCICallback.Reason.NEED_USERID,           params.getProperty("userid",System.getProperty("userid","")));
+        this.callbackValues.put(HBCICallback.Reason.NEED_PT_PIN,           params.getProperty("pin",System.getProperty("pin","")));
+        this.callbackValues.put(HBCICallback.Reason.NEED_PT_SECMECH,       params.getProperty("secmech",System.getProperty("secmech","")));
 
         // Das Passport-Passwort
-        this.callbackValues.put(HBCICallback.NEED_PASSPHRASE_LOAD,  params.getProperty("password",System.getProperty("password","")));
-        this.callbackValues.put(HBCICallback.NEED_PASSPHRASE_SAVE,  params.getProperty("password",System.getProperty("password","")));
+        this.callbackValues.put(HBCICallback.Reason.NEED_PASSPHRASE_LOAD,  params.getProperty("password",System.getProperty("password","")));
+        this.callbackValues.put(HBCICallback.Reason.NEED_PASSPHRASE_SAVE,  params.getProperty("password",System.getProperty("password","")));
 
         final String blz = params.getProperty("blz",System.getProperty("blz"));
-        this.callbackValues.put(HBCICallback.NEED_BLZ,              blz);
-        this.callbackValues.put(HBCICallback.NEED_PORT,             params.getProperty("port",System.getProperty("port","443")));
-        this.callbackValues.put(HBCICallback.NEED_FILTER,           params.getProperty("filter",System.getProperty("filter","Base64")));
-        this.callbackValues.put(HBCICallback.NEED_CONNECTION,       "");
-        this.callbackValues.put(HBCICallback.CLOSE_CONNECTION,      "");
+        this.callbackValues.put(HBCICallback.Reason.NEED_BLZ,              blz);
+        this.callbackValues.put(HBCICallback.Reason.NEED_PORT,             params.getProperty("port",System.getProperty("port","443")));
+        this.callbackValues.put(HBCICallback.Reason.NEED_FILTER,           params.getProperty("filter",System.getProperty("filter","Base64")));
+        this.callbackValues.put(HBCICallback.Reason.NEED_CONNECTION,       "");
+        this.callbackValues.put(HBCICallback.Reason.CLOSE_CONNECTION,      "");
 
               
         // Initialisierungsparameter fuer HBCI4Java selbst
@@ -128,10 +128,10 @@ public abstract class AbstractTestGV
         final HBCICallback callback = new HBCICallbackIOStreams(out,new BufferedReader(new InputStreamReader(System.in)))
         {
             /**
-             * @see org.kapott.hbci.callback.HBCICallbackIOStreams#callback(org.kapott.hbci.passport.HBCIPassport, int, java.lang.String, int, java.lang.StringBuffer)
+             * @see org.kapott.hbci.callback.HBCICallbackIOStreams#callback(org.kapott.hbci.passport.HBCIPassport, Reason, java.lang.String, ResponseType, java.lang.StringBuffer)
              */
             @Override
-            public void callback(HBCIPassport passport, int reason, String msg, int datatype, StringBuffer retData) {
+            public void callback(HBCIPassport passport, Reason reason, String msg, ResponseType datatype, StringBuffer retData) {
                 
                 // haben wir einen vordefinierten Wert?
                 String value = callbackValues.get(reason);
@@ -173,7 +173,7 @@ public abstract class AbstractTestGV
             if (bank != null)
                 host = bank.getPinTanAddress();
         }
-        this.callbackValues.put(HBCICallback.NEED_HOST,host);
+        this.callbackValues.put(HBCICallback.Reason.NEED_HOST,host);
         //
         ////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
Erhöhe Typsicherheit, indem die Konstanten fachlich in Enums gebündelt werden. Dadurch muss keine Prüfung auf fehlerhafte Eingabewerte (< 0, invalider Wert, etc.) erfolgen und für den Entwickler ist besser ersichtlich, was als Parameter erwartet wird (--> Autovervollständigung der IDE).

Innerhalb der aufrufenden Klassen wird der Code dadurch ebenfalls sprechender/ besser verständlich.