### PR TITLE
Javadoc-Korrekturen

### DIFF
--- a/src/main/java/org/kapott/hbci/GV/GVKUmsAll.java
+++ b/src/main/java/org/kapott/hbci/GV/GVKUmsAll.java
@@ -79,7 +79,7 @@ public class GVKUmsAll extends HBCIJobImpl
         // Dennoch kann es sein, dass die nationale Bankverbindung auch bei der
         // SEPA-Variante noch mitgeschickt wird, wenn die Bank das zulaesst.
         // (Es scheint auch Banken zu geben, die das in dem Fall nicht nur
-        // zulassen sondern erwarten).
+        // zulassen, sondern erwarten).
         boolean nat = this.canNationalAcc(handler);
 
         if (sepa)

--- a/src/main/java/org/kapott/hbci/GV/GVKUmsNew.java
+++ b/src/main/java/org/kapott/hbci/GV/GVKUmsNew.java
@@ -62,7 +62,7 @@ public final class GVKUmsNew extends GVKUmsAll
         // Dennoch kann es sein, dass die nationale Bankverbindung auch bei der
         // SEPA-Variante noch mitgeschickt wird, wenn die Bank das zulaesst.
         // (Es scheint auch Banken zu geben, die das in dem Fall nicht nur
-        // zulassen sondern erwarten).
+        // zulassen, sondern erwarten).
         boolean nat = this.canNationalAcc(handler);
 
         if (sepa)

--- a/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
+++ b/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
@@ -202,11 +202,11 @@ public class GVTAN2Step extends HBCIJobImpl
 
         ///////////////////////////////////////////////////////////////////////
         // Die folgenden Sonderbehandlungen sind nur bei Prozess-Variante 2 in Schritt 2 noetig,
-        // weil wir dort ein Response auf einen GV erhalten, wir selbst aber gar nicht der GV sind sondern das HKTAN Step2
+        // weil wir dort ein Response auf einen GV erhalten, wir selbst aber gar nicht der GV sind, sondern das HKTAN Step2
         if (this.process == KnownTANProcess.PROCESS2_STEP2 && this.task != null)
         {
             // Pruefen, ob die Bank eventuell ein 3040 gesendet hat - sie also noch weitere Daten braucht.
-            // Das 3040 bezieht sich dann aber nicht auf unser HKTAN sondern auf den eigentlichen GV
+            // Das 3040 bezieht sich dann aber nicht auf unser HKTAN, sondern auf den eigentlichen GV
             // In dem Fall muessen wir dem eigentlichen Task mitteilen, dass er erneut ausgefuehrt werden soll.
             if (StringUtil.toInsCode(this.getHBCICode()).equals(segCode) && KnownReturncode.W3040.searchReturnValue(msgstatus.segStatus.getWarnings()) != null && this.task.redoAllowed())
             {

--- a/src/main/java/org/kapott/hbci/GV/SepaUtil.java
+++ b/src/main/java/org/kapott/hbci/GV/SepaUtil.java
@@ -193,7 +193,7 @@ public class SepaUtil
     
     /**
      * Liefert den Wert des Properties oder den Default-Wert.
-     * Der Default-Wert wird nicht nur bei NULL verwendet sondern auch bei Leerstring.
+     * Der Default-Wert wird nicht nur bei NULL verwendet, sondern auch bei Leerstring.
      * @param props die Properties.
      * @param name der Name des Properties.
      * @param defaultValue der Default-Wert.

--- a/src/main/java/org/kapott/hbci/callback/HBCICallback.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallback.java
@@ -555,7 +555,7 @@ public interface HBCICallback
      * Wie STATUS_MSG_RAW_RECV - jedoch noch vor der Entschluesselung der Daten.
      * Abhaengig vom HBCI-Verfahren kann die Nachricht aber auch hier bereits entschluesselt
      * sein. Naemlich bei HBCI-Verfahren, bei denen die Verschluesselung nicht auf
-     * im HBCI-Protokoll selbst stattfindet sondern auf dem Transport-Protokoll.
+     * im HBCI-Protokoll selbst stattfindet, sondern auf dem Transport-Protokoll.
      * Konkret ist das PIN/TAN. Bei Schluesseldatei und Chipkarte hingegen ist die
      * Message zu diesem Zeitpunkt hier noch verschluesselt.
      */

--- a/src/main/java/org/kapott/hbci/dialog/HBCIDialogEnd.java
+++ b/src/main/java/org/kapott/hbci/dialog/HBCIDialogEnd.java
@@ -49,7 +49,7 @@ public class HBCIDialogEnd extends AbstractRawHBCIDialog
         SIG_ID,
         
         /**
-         * Fehler werden nicht geworfen sondern nur geloggt.
+         * Fehler werden nicht geworfen, sondern nur geloggt.
          * Muss nur explizit angegeben werden, wenn es kein anonymer Dialog ist oder das Werfen per "client.errors.ignoreDialogEndErrors" abgeschaltet ist.
          */
         ACCEPT_ERROR,

--- a/src/main/java/org/kapott/hbci/dialog/KnownTANProcess.java
+++ b/src/main/java/org/kapott/hbci/dialog/KnownTANProcess.java
@@ -79,7 +79,7 @@ public enum KnownTANProcess
         
         /**
          * Liefert die zu verwendende Prozessvariante.
-         * @param code der Code der Variante. Nie NULL sondern hoechstens die Default-Variante.
+         * @param code der Code der Variante. Nie NULL, sondern hoechstens die Default-Variante.
          * @return die Prozess-Variante.
          */
         public final static Variant determine(String code)
@@ -131,7 +131,7 @@ public enum KnownTANProcess
      * Ermittelt den passenden TAN-Prozess fuer die Variante und die Schritt-Nummer.
      * @param v die Prozess-Variante.
      * @param step die Schritt-Nummer.
-     * @return der TAN-Prozess. Nie NULL sondern im Zweifel {@link KnownTANProcess#PROCESS2_STEP1}.
+     * @return der TAN-Prozess. Nie NULL, sondern im Zweifel {@link KnownTANProcess#PROCESS2_STEP1}.
      */
     public static KnownTANProcess get(Variant v, int step)
     {

--- a/src/main/java/org/kapott/hbci/examples/UmsatzAbrufPinTan.java
+++ b/src/main/java/org/kapott/hbci/examples/UmsatzAbrufPinTan.java
@@ -295,7 +295,7 @@ public class UmsatzAbrufPinTan
               // Die Variable "msg" aus der Methoden-Signatur enthaelt uebrigens
               // den bankspezifischen Text mit den Instruktionen fuer den User.
               // Der Text aus "msg" sollte daher im Dialog dem User angezeigt
-              // werden. Da Sparkassen den eigentlichen Bild u.U. auch in msg verpacken,
+              // werden. Da Sparkassen das eigentliche Bild u.U. auch in msg verpacken,
               // sollte zur Anzeige nicht der originale Text verwendet werden, sondern
               // der von QRCode - dort ist dann die ggf. enthaltene Base64-codierte QR-Grafik entfernt
               // msg = code.getMessage();

--- a/src/main/java/org/kapott/hbci/examples/UmsatzAbrufPinTan.java
+++ b/src/main/java/org/kapott/hbci/examples/UmsatzAbrufPinTan.java
@@ -296,7 +296,7 @@ public class UmsatzAbrufPinTan
               // den bankspezifischen Text mit den Instruktionen fuer den User.
               // Der Text aus "msg" sollte daher im Dialog dem User angezeigt
               // werden. Da Sparkassen den eigentlichen Bild u.U. auch in msg verpacken,
-              // sollte zur Anzeige nicht der originale Text verwendet werden sondern
+              // sollte zur Anzeige nicht der originale Text verwendet werden, sondern
               // der von QRCode - dort ist dann die ggf. enthaltene Base64-codierte QR-Grafik entfernt
               // msg = code.getMessage();
               String tan = null;

--- a/src/main/java/org/kapott/hbci/manager/BankInfo.java
+++ b/src/main/java/org/kapott/hbci/manager/BankInfo.java
@@ -202,7 +202,7 @@ public class BankInfo
     /**
      * Parst die BankInfo-Daten aus einer Zeile der blz.properties.
      * @param text der Text (Value) aus der blz.properties.
-     * @return das BankInfo-Objekt. Niemals NULL sondern hoechstens ein leeres Objekt.
+     * @return das BankInfo-Objekt. Niemals NULL, sondern hoechstens ein leeres Objekt.
      */
     static BankInfo parse(String text)
     {

--- a/src/main/java/org/kapott/hbci/manager/FlickerCode.java
+++ b/src/main/java/org/kapott/hbci/manager/FlickerCode.java
@@ -102,7 +102,7 @@ public class FlickerCode
   /**
    * Die Anzahl der Bytes, in der die Laenge des Challenge bei HHD 1.4 steht.
    * Bei HHD 1.3 war das noch 2 Zeichen lang.
-   * Wenn der Flicker-Code nicht in "Challenge HHDuc" uebertragen wurde
+   * Wenn der Flicker-Code nicht in "Challenge HHDuc" uebertragen wurde,
    * sondern direkt im Freitext-Challenge, koennen wir das Problem umgehen,
    * indem wir in clean() einfach eine "0" vorn anhaengen.
    * Wenn er aber tatsaechlich im "Challenge HHDuc" steht, kann man dem
@@ -354,7 +354,7 @@ public class FlickerCode
   /**
    * Entfernt das CHLGUC0026....CHLGTEXT aus dem Code, falls vorhanden.
    * Das sind HHD 1.3-Codes, die nicht im "Challenge HHDuc" uebertragen
-   * wurden sondern direkt im Challenge-Freitext,
+   * wurden, sondern direkt im Challenge-Freitext,
    * @param code
    * @return
    */
@@ -375,7 +375,7 @@ public class FlickerCode
     // Dann alles abschneiden bis zum Beginn von "CHLGUC"
     code = code.substring(t1Start);
 
-    // Wir haben eigentlich nicht nur "CHLGUC" sondern "CHLGUC0026"
+    // Wir haben eigentlich nicht nur "CHLGUC", sondern "CHLGUC0026"
     // Wobei die 4 Zahlen sicher variieren koennen. Wir schneiden einfach alles ab.
     code = code.substring(10);
     
@@ -768,7 +768,7 @@ public class FlickerCode
    * Selbstverstaendlich sind hier so einige Sachen anders codiert als im DE.
    * Waer ja auch zu einfach sonst.
    * Die Laengen-Angabe ist anders codiert (hex statt dec). Und nach der
-   * Laenge kommen nicht sofort die Nutzdaten sondern erst noch die Control-Bytes.
+   * Laenge kommen nicht sofort die Nutzdaten, sondern erst noch die Control-Bytes.
    */
   public class Startcode extends DE
   {

--- a/src/main/java/org/kapott/hbci/manager/HBCIUser.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUser.java
@@ -538,9 +538,9 @@ public final class HBCIUser implements IHandlerData
         p.setProperty(UPD_KEY_HBCIVERSION,kernel.getHBCIVersion());
         
         ///////////////////////////////////////////////////////////////////
-        // Die UPD-Keys sicher, die nicht direkt von der Bank kommen sondern
+        // Die UPD-Keys sicher, die nicht direkt von der Bank kommen, sondern
         // von uns. Eigentlich sollten die nicht direkt in den UPD-Properties
-        // gespeichert sondern separat. Dazu muesste ich aber die Datenstruktur
+        // gespeichert, sondern separat. Dazu muesste ich aber die Datenstruktur
         // von PassportData erweitern und das auch bei allen anderen Passports
         // nachziehen sowie eine Migration einbauen. Dafuer lohnt sich das nicht.
         final Map<String,String> protectedKeys = new HashMap<String,String>();

--- a/src/main/java/org/kapott/hbci/manager/HBCIUser.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUser.java
@@ -540,7 +540,7 @@ public final class HBCIUser implements IHandlerData
         ///////////////////////////////////////////////////////////////////
         // Die UPD-Keys sicher, die nicht direkt von der Bank kommen, sondern
         // von uns. Eigentlich sollten die nicht direkt in den UPD-Properties
-        // gespeichert, sondern separat. Dazu muesste ich aber die Datenstruktur
+        // gespeichert werden, sondern separat. Dazu muesste ich aber die Datenstruktur
         // von PassportData erweitern und das auch bei allen anderen Passports
         // nachziehen sowie eine Migration einbauen. Dafuer lohnt sich das nicht.
         final Map<String,String> protectedKeys = new HashMap<String,String>();

--- a/src/main/java/org/kapott/hbci/manager/HBCIUtils.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUtils.java
@@ -1216,7 +1216,7 @@ public final class HBCIUtils
 	 *            im Ort der Bank oder in deren Namen enthalten sein. Oder die
 	 *            BLZ oder BIC beginnt mit diesem Text.
 	 * @return die Liste der Bank-Informationen. Die Ergebnis-Liste ist nach BLZ
-	 *         sortiert. Die Funktion liefert niemals NULL sondern hoechstens
+	 *         sortiert. Die Funktion liefert niemals NULL, sondern hoechstens
 	 *         eine leere Liste.
 	 */
 	public static List<BankInfo> searchBankInfo ( String query )

--- a/src/main/java/org/kapott/hbci/manager/QRCode.java
+++ b/src/main/java/org/kapott/hbci/manager/QRCode.java
@@ -126,7 +126,7 @@ public class QRCode
             // Dann alles abschneiden bis zum Beginn von "CHLGUC"
             code = code.substring(t1Start);
 
-            // Wir haben eigentlich nicht nur "CHLGUC" sondern "CHLGUCXXXX"
+            // Wir haben eigentlich nicht nur "CHLGUC", sondern "CHLGUCXXXX"
             // Wobei die 4 Zahlen die Laenge des Codes angeben. Wir schneiden einfach alles ab.
             code = code.substring(10);
             
@@ -150,7 +150,7 @@ public class QRCode
 
         int t1Start = msg.indexOf("CHLGTEXT");
         
-        // Wir haben eigentlich nicht nur "CHLGTEXT" sondern "CHLGTEXTXXXX"
+        // Wir haben eigentlich nicht nur "CHLGTEXT", sondern "CHLGTEXTXXXX"
         // Wobei die 4 Zahlen die Laenge des Textes angeben. Wir schneiden einfach alles bis dahin ab.
         this.text = msg.substring(t1Start+12);
         //

--- a/src/main/java/org/kapott/hbci/passport/AbstractPinTanPassport.java
+++ b/src/main/java/org/kapott/hbci/passport/AbstractPinTanPassport.java
@@ -860,7 +860,7 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
         if (options.size() == 0)
         {
             // wir lassen das hier mal noch auf true stehen, weil das bestimmt noch nicht final war. Schliesslich basierte die
-            // Auswahl des Verfahrens nicht auf den fuer den User freigeschalteten Verfahren sondern nur den allgemein von der
+            // Auswahl des Verfahrens nicht auf den fuer den User freigeschalteten Verfahren, sondern nur den allgemein von der
             // Bank unterstuetzten
             this.tanMethodAutoSelected = true;
             

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportPinTanMemory.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportPinTanMemory.java
@@ -22,7 +22,7 @@
 package org.kapott.hbci.passport;
 
 /**
- * Implementierung eines PIN/TAN-Passport, welcher keine Daten im Dateisystem ablegt
+ * Implementierung eines PIN/TAN-Passport, welcher keine Daten im Dateisystem ablegt,
  * sondern alle Daten im Speicher haelt.
  */
 public class HBCIPassportPinTanMemory extends HBCIPassportPinTan

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportRAH10.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportRAH10.java
@@ -476,7 +476,7 @@ public class HBCIPassportRAH10 extends AbstractHBCIPassport implements InitLette
     {
         // Bei RDH/RAH wird doppelt gehasht.
         // Die Signatur selbst wird bereits auf einem Hash der Daten durchgefuehrt.
-        // Die Spec schreibt aber vor, dass nicht die Daten signiert werden sondern
+        // Die Spec schreibt aber vor, dass nicht die Daten signiert werden, sondern
         // der Hash. Also doppelt
         return CryptUtils.hash(data,CryptUtils.HASH_ALG_SHA256);
     }

--- a/src/main/java/org/kapott/hbci/passport/storage/PassportStorage.java
+++ b/src/main/java/org/kapott/hbci/passport/storage/PassportStorage.java
@@ -107,7 +107,7 @@ public class PassportStorage
             // Wir laden die Datei erstmal komplett in den Speicher, damit wir die Formate durchprobieren koennen
             byte[] data = IOUtils.read(is);
             
-            // Wenn die Datei leer ist, brauchen wir sie nicht einlesen sondern liefern einfach ein leeres
+            // Wenn die Datei leer ist, brauchen wir sie nicht einlesen, sondern liefern einfach ein leeres
             // PassportData-Objekt. Dann werfen wir naemlich keinen Fehler beim Laden, wenn das Schreiben einer
             // Passport-Datei mal fehlschlug und sie als leere Datei erzeugt wurde. Stattdessen erstellen wir
             // einfach einen neuen Passport.

--- a/src/main/java/org/kapott/hbci/tools/IOUtils.java
+++ b/src/main/java/org/kapott/hbci/tools/IOUtils.java
@@ -43,7 +43,7 @@ public class IOUtils
      * sie wirklich verschwunden ist, bevor tmpFile auf den Namen von origFile umbenannt wird.
      * Wichtig ist, dass zum Zeitpunkt des Aufrufes dieser Methode alle Streams auf die
      * Dateien bereits geschlossen wurden. Die Schreibvorgaenge auf die Dateien muessen also
-     * abgeschlossen sein. Heisst: "os.close()" nicht erst im finally-Block machen sondern
+     * abgeschlossen sein. Heisst: "os.close()" nicht erst im finally-Block machen, sondern
      * VOR dem Aufruf dieser Methode.
      * @param origFile die originale zu ersetzende Datei.
      * @param tmpFile die neue Datei, welche die originale ersetzen soll.

--- a/src/main/java/org/kapott/hbci/tools/ParameterFinder.java
+++ b/src/main/java/org/kapott/hbci/tools/ParameterFinder.java
@@ -89,8 +89,8 @@ public class ParameterFinder
      * Sucht in props nach allen Schluesseln im genannten Pfad und liefert sie zurueck.
      * @param props die Properties, in denen gesucht werden soll.
      * @param query das Query.
-     * @return Liefert die gefundenen Properties. Niemals NULL sondern hoechstens leere Properties.
-     * Als Schluessel wird jeweils nicht der gesamte Pfad verwendet sondern nur der Teil hinter dem letzten Punkt.
+     * @return Liefert die gefundenen Properties. Niemals NULL, sondern hoechstens leere Properties.
+     * Als Schluessel wird jeweils nicht der gesamte Pfad verwendet, sondern nur der Teil hinter dem letzten Punkt.
      */
     public static Properties find(Properties props, Query query)
     {
@@ -102,8 +102,8 @@ public class ParameterFinder
      * @param props die Properties, in denen gesucht werden soll.
      * @param path der Pfad. Es koennen Wildcards verwendet werden.
      * Etwa so: Params_*.TAN2StepPar*.ParTAN2Step*.TAN2StepParams*.*secfunc")
-     * @return Liefert die gefundenen Properties. Niemals NULL sondern hoechstens leere Properties.
-     * Als Schluessel wird jeweils nicht der gesamte Pfad verwendet sondern nur der Teil hinter dem letzten Punkt.
+     * @return Liefert die gefundenen Properties. Niemals NULL, sondern hoechstens leere Properties.
+     * Als Schluessel wird jeweils nicht der gesamte Pfad verwendet, sondern nur der Teil hinter dem letzten Punkt.
      */
     public static Properties find(Properties props, String path)
     {
@@ -157,7 +157,7 @@ public class ParameterFinder
      * wenn man ueber grosse Bereiche sucht und die Namen des letzen Elements im Baum gleich lauten koennen.
      * @param props die Properties, in denen gesucht werden soll.
      * @param query das Query.
-     * @return Liefert die gefundenen Properties. Niemals NULL sondern hoechstens leere Properties.
+     * @return Liefert die gefundenen Properties. Niemals NULL, sondern hoechstens leere Properties.
      */
     public static Properties findAll(Properties props, Query query)
     {
@@ -171,7 +171,7 @@ public class ParameterFinder
      * @param props die Properties, in denen gesucht werden soll.
      * @param path der Pfad. Es koennen Wildcards verwendet werden.
      * Etwa so: Params_*.TAN2StepPar*.ParTAN2Step*.TAN2StepParams*.*secfunc")
-     * @return Liefert die gefundenen Properties. Niemals NULL sondern hoechstens leere Properties.
+     * @return Liefert die gefundenen Properties. Niemals NULL, sondern hoechstens leere Properties.
      */
     public static Properties findAll(Properties props, String path)
     {

--- a/src/test/java/org/kapott/hbci4java/secmech/FlickerTest.java
+++ b/src/test/java/org/kapott/hbci4java/secmech/FlickerTest.java
@@ -165,7 +165,7 @@ public class FlickerTest extends AbstractTest
   public void test4() throws Exception
   {
     // Code von http://www.onlinebanking-forum.de/phpBB2/viewtopic.php?p=60532
-    // Stammt nicht aus dem "Challenge HHDuc" sondern aus dem Freitext
+    // Stammt nicht aus dem "Challenge HHDuc", sondern aus dem Freitext
     // des TAN-Dialoges
     // Das zwischen "CHLGUC$4zahlen" und "CHLGTEXT" ist der Flickercode.
     // Das $4zahlen gibt IMHO an, wie lang der danach folgende Flicker-Code ist
@@ -252,7 +252,7 @@ public class FlickerTest extends AbstractTest
   }
   
   /**
-   * Das ist ein "echter" HHD-1.3-Code, der nicht im Challenge-Freitext sondern
+   * Das ist ein "echter" HHD-1.3-Code, der nicht im Challenge-Freitext, sondern
    * tatsaechlich im Challenge HHDuc uebertragen wurde. Erkennbar daran, dass
    * das LC nur 2 Zeichen lang ist. Stammt von der Postbank.
    * @throws Exception


### PR DESCRIPTION
Im Zuge meiner Einarbeitung in den Code sind mir einige Dinge aufgefallen. Dieser Pullrequest konzentriert sich auf die Dokumentation (Javadoc) und die folgenden Anpassungen daran:

- Vor dem Wort "sondern" kommt immer ein Komma (siehe [Duden](https://www.duden.de/sprachwissen/sprachratgeber/Besonderheiten-von-sondern))
- zwei Grammatikfehler korrigiert in `UmsatzAbrufPinTan` und `HBCIUser`