### PR TITLE
Refactoring: Verständlichkeit erhöht in `GVTAN2Step` und `HBCIJobImpl`

### DIFF
--- a/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
+++ b/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
@@ -62,8 +62,8 @@ public class GVTAN2Step extends HBCIJobImpl
     }
     
     /**
-     * Speichert den Prozess-Schritt des HKTAN.
-     * @param p der Prozess-Schritt.
+     * Speichert den Prozessschritt des HKTAN.
+     * @param p der Prozessschritt.
      */
     public void setProcess(KnownTANProcess p)
     {
@@ -146,7 +146,7 @@ public class GVTAN2Step extends HBCIJobImpl
 
     /**
      * Speichert die Referenz auf das zweite HKTAN im ersten HKTAN.
-     * Wird fuer Prozess-Variante 2 benoetigt.
+     * Wird fuer Prozessvariante 2 benoetigt.
      * @param step2 die Referenz auf den ersten HKTAN.
      */
     public void setStep2(GVTAN2Step step2)
@@ -198,7 +198,7 @@ public class GVTAN2Step extends HBCIJobImpl
         final String segCode = result.getProperty(header+".SegHead.code"); // HITAN oder das HI** des GV
         HBCIUtils.log("found HKTAN response with segcode " + segCode,HBCIUtils.LOG_DEBUG);
 
-        // Die folgenden Sonderbehandlungen sind nur bei Prozess-Variante 2 in Schritt 2 noetig,
+        // Die folgenden Sonderbehandlungen sind nur bei Prozessvariante 2 in Schritt 2 noetig,
         // weil wir dort ein Response auf einen GV erhalten, wir selbst aber gar nicht der GV sind sondern das HKTAN Step2
         if (this.process == PROCESS2_STEP2 && this.task != null)
         {
@@ -236,7 +236,7 @@ public class GVTAN2Step extends HBCIJobImpl
             p.setPersistentData(AbstractPinTanPassport.KEY_PD_SCA,"true"); // Bewirkt, dass die TAN-Abfrage nicht erscheint
             if (this.step2 != null)
             {
-                // Bewirkt, dass das zweite HKTAN bei Prozess-Variante 2 nicht mehr gesendet wird
+                // Bewirkt, dass das zweite HKTAN bei Prozessvariante 2 nicht mehr gesendet wird
                 this.step2.skip();
             }
             return;
@@ -244,7 +244,7 @@ public class GVTAN2Step extends HBCIJobImpl
 
         //region: Daten fuer die TAN-Abfrage einsammeln
         
-        // Prozess-Variante 1:
+        // Prozessvariante 1:
         final String challenge = result.getProperty(header+".challenge");
         if (challenge != null)
         {

--- a/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
+++ b/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
@@ -264,10 +264,10 @@ public class GVTAN2Step extends HBCIJobImpl
         // Die Auftragsreferenz aus dem ersten HITAN bei Prozessvariante 2. Die muessen wir bei dem HKTAN#2 mitschicken, damit die Bank
         // weiss, auf welchen Auftrag sich die TAN bezieht
         final String orderref = result.getProperty(header+".orderref");
-        if (step2 != null && orderref != null)
+        if (this.step2 != null && orderref != null)
         {
             HBCIUtils.log("found orderref '" + orderref + "' in HITAN",HBCIUtils.LOG_DEBUG);
-            step2.setParam("orderref",orderref);
+            this.step2.setParam("orderref",orderref);
         }
         //
         ///////////////////////////////////////////////////////////////////////

--- a/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
+++ b/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
@@ -36,6 +36,9 @@ import org.kapott.hbci.tools.StringUtil;
 
 import static org.kapott.hbci.dialog.KnownReturncode.W3040;
 import static org.kapott.hbci.dialog.KnownReturncode.W3076;
+import static org.kapott.hbci.dialog.KnownTANProcess.PROCESS1;
+import static org.kapott.hbci.dialog.KnownTANProcess.PROCESS2_STEP1;
+import static org.kapott.hbci.dialog.KnownTANProcess.PROCESS2_STEP2;
 
 /**
  * @author stefan.palme
@@ -195,7 +198,7 @@ public class GVTAN2Step extends HBCIJobImpl
         ///////////////////////////////////////////////////////////////////////
         // Die folgenden Sonderbehandlungen sind nur bei Prozess-Variante 2 in Schritt 2 noetig,
         // weil wir dort ein Response auf einen GV erhalten, wir selbst aber gar nicht der GV sind sondern das HKTAN Step2
-        if (this.process == KnownTANProcess.PROCESS2_STEP2 && this.task != null)
+        if (this.process == PROCESS2_STEP2 && this.task != null)
         {
             // Pruefen, ob die Bank eventuell ein 3040 gesendet hat - sie also noch weitere Daten braucht.
             // Das 3040 bezieht sich dann aber nicht auf unser HKTAN sondern auf den eigentlichen GV
@@ -227,7 +230,7 @@ public class GVTAN2Step extends HBCIJobImpl
         ///////////////////////////////////////////////////////////////////////
         // SCA-Ausnahme checken. Wenn wir in der Auswertung des ersten HKTAN sind, pruefen wir, ob die Bank einen 3076 geschickt
         // hat. Wenn das der Fall ist, koennen wir das zweite HKTAN weglassen und muessen auch beim User keine TAN erfragen
-        if ((this.process == KnownTANProcess.PROCESS1 || this.process == KnownTANProcess.PROCESS2_STEP1) && (W3076.searchReturnValue(msgstatus.segStatus.getWarnings()) != null || W3076.searchReturnValue(msgstatus.globStatus.getWarnings()) != null))
+        if ((this.process == PROCESS1 || this.process == PROCESS2_STEP1) && (W3076.searchReturnValue(msgstatus.segStatus.getWarnings()) != null || W3076.searchReturnValue(msgstatus.globStatus.getWarnings()) != null))
         {
             HBCIUtils.log("found status code 3076, no SCA required",HBCIUtils.LOG_DEBUG);
             p.setPersistentData(AbstractPinTanPassport.KEY_PD_SCA,"true"); // Bewirkt, dass die TAN-Abfrage nicht erscheint

--- a/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
+++ b/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
@@ -32,13 +32,13 @@ import org.kapott.hbci.manager.LogFilter;
 import org.kapott.hbci.passport.AbstractPinTanPassport;
 import org.kapott.hbci.passport.HBCIPassportInternal;
 import org.kapott.hbci.status.HBCIMsgStatus;
-import org.kapott.hbci.tools.StringUtil;
 
 import static org.kapott.hbci.dialog.KnownReturncode.W3040;
 import static org.kapott.hbci.dialog.KnownReturncode.W3076;
 import static org.kapott.hbci.dialog.KnownTANProcess.PROCESS1;
 import static org.kapott.hbci.dialog.KnownTANProcess.PROCESS2_STEP1;
 import static org.kapott.hbci.dialog.KnownTANProcess.PROCESS2_STEP2;
+import static org.kapott.hbci.tools.StringUtil.toInsCode;
 
 /**
  * @author stefan.palme
@@ -203,7 +203,7 @@ public class GVTAN2Step extends HBCIJobImpl
             // Pruefen, ob die Bank eventuell ein 3040 gesendet hat - sie also noch weitere Daten braucht.
             // Das 3040 bezieht sich dann aber nicht auf unser HKTAN sondern auf den eigentlichen GV
             // In dem Fall muessen wir dem eigentlichen Task mitteilen, dass er erneut ausgefuehrt werden soll.
-            if (StringUtil.toInsCode(this.getHBCICode()).equals(segCode) && W3040.isIn(msgstatus.segStatus.getWarnings()) && this.task.redoAllowed())
+            if (toInsCode(this.getHBCICode()).equals(segCode) && W3040.isIn(msgstatus.segStatus.getWarnings()) && this.task.redoAllowed())
             {
                 HBCIUtils.log("found status code 3040, need to repeat task " + this.task.getHBCICode(),HBCIUtils.LOG_DEBUG);
                 HBCIUtils.log("Weitere Daten folgen",HBCIUtils.LOG_INFO);
@@ -212,7 +212,7 @@ public class GVTAN2Step extends HBCIJobImpl
 
             // Das ist das Response auf den eigentlichen GV - an den Task durchreichen
             // Muessen wir extra pruefen, weil das hier auch das HITAN sein koennte. Das schauen wir aber nicht an
-            if (StringUtil.toInsCode(this.task.getHBCICode()).equals(segCode))
+            if (toInsCode(this.task.getHBCICode()).equals(segCode))
             {
                 HBCIUtils.log("this is a response segment for the original task (" + this.task.getName() + ") - storing results in the original job",HBCIUtils.LOG_DEBUG);
                 this.task.fillJobResultFromTanJob(msgstatus, header, idx);

--- a/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
+++ b/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
@@ -237,7 +237,7 @@ public class GVTAN2Step extends HBCIJobImpl
             return;
         }
 
-        // Daten fuer die TAN-Abfrage einsammeln
+        //region: Daten fuer die TAN-Abfrage einsammeln
         
         // Prozess-Variante 1:
         final String challenge = result.getProperty(header+".challenge");
@@ -266,5 +266,6 @@ public class GVTAN2Step extends HBCIJobImpl
             HBCIUtils.log("found orderref '" + orderref + "' in HITAN",HBCIUtils.LOG_DEBUG);
             this.step2.setParam("orderref",orderref);
         }
+        //endregion
     }
 }

--- a/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
+++ b/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
@@ -129,9 +129,7 @@ public class GVTAN2Step extends HBCIJobImpl
 
     }
     
-    /**
-     * @see org.kapott.hbci.GV.HBCIJobImpl#setParam(java.lang.String, java.lang.String)
-     */
+    @Override
     public void setParam(String paramName, String value)
     {
         if (paramName.equals("orderhash")) {
@@ -158,7 +156,8 @@ public class GVTAN2Step extends HBCIJobImpl
     {
         this.task = task;
     }
-    
+
+    @Override
     protected void saveReturnValues(HBCIMsgStatus status, int sref)
     {
         super.saveReturnValues(status, sref);
@@ -171,18 +170,12 @@ public class GVTAN2Step extends HBCIJobImpl
         }
     }
     
-    /**
-     * @see org.kapott.hbci.GV.HBCIJobImpl#redo()
-     */
     @Override
     public HBCIJobImpl redo()
     {
         return this.redo;
     }
     
-    /**
-     * @see org.kapott.hbci.GV.HBCIJobImpl#haveTan()
-     */
     @Override
     public boolean haveTan()
     {
@@ -191,9 +184,6 @@ public class GVTAN2Step extends HBCIJobImpl
         return true;
     }
     
-    /**
-     * @see org.kapott.hbci.GV.HBCIJobImpl#extractResults(org.kapott.hbci.status.HBCIMsgStatus, java.lang.String, int)
-     */
     protected void extractResults(HBCIMsgStatus msgstatus,String header,int idx)
     {
         final Properties result = msgstatus.getData();

--- a/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
+++ b/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
@@ -25,7 +25,6 @@ package org.kapott.hbci.GV;
 import java.util.Properties;
 
 import org.kapott.hbci.GV_Result.GVRSaldoReq;
-import org.kapott.hbci.dialog.KnownReturncode;
 import org.kapott.hbci.dialog.KnownTANProcess;
 import org.kapott.hbci.manager.HBCIHandler;
 import org.kapott.hbci.manager.HBCIUtils;
@@ -34,6 +33,9 @@ import org.kapott.hbci.passport.AbstractPinTanPassport;
 import org.kapott.hbci.passport.HBCIPassportInternal;
 import org.kapott.hbci.status.HBCIMsgStatus;
 import org.kapott.hbci.tools.StringUtil;
+
+import static org.kapott.hbci.dialog.KnownReturncode.W3040;
+import static org.kapott.hbci.dialog.KnownReturncode.W3076;
 
 /**
  * @author stefan.palme
@@ -198,7 +200,7 @@ public class GVTAN2Step extends HBCIJobImpl
             // Pruefen, ob die Bank eventuell ein 3040 gesendet hat - sie also noch weitere Daten braucht.
             // Das 3040 bezieht sich dann aber nicht auf unser HKTAN sondern auf den eigentlichen GV
             // In dem Fall muessen wir dem eigentlichen Task mitteilen, dass er erneut ausgefuehrt werden soll.
-            if (StringUtil.toInsCode(this.getHBCICode()).equals(segCode) && KnownReturncode.W3040.searchReturnValue(msgstatus.segStatus.getWarnings()) != null && this.task.redoAllowed())
+            if (StringUtil.toInsCode(this.getHBCICode()).equals(segCode) && W3040.searchReturnValue(msgstatus.segStatus.getWarnings()) != null && this.task.redoAllowed())
             {
                 HBCIUtils.log("found status code 3040, need to repeat task " + this.task.getHBCICode(),HBCIUtils.LOG_DEBUG);
                 HBCIUtils.log("Weitere Daten folgen",HBCIUtils.LOG_INFO);
@@ -225,7 +227,7 @@ public class GVTAN2Step extends HBCIJobImpl
         ///////////////////////////////////////////////////////////////////////
         // SCA-Ausnahme checken. Wenn wir in der Auswertung des ersten HKTAN sind, pruefen wir, ob die Bank einen 3076 geschickt
         // hat. Wenn das der Fall ist, koennen wir das zweite HKTAN weglassen und muessen auch beim User keine TAN erfragen
-        if ((this.process == KnownTANProcess.PROCESS1 || this.process == KnownTANProcess.PROCESS2_STEP1) && (KnownReturncode.W3076.searchReturnValue(msgstatus.segStatus.getWarnings()) != null || KnownReturncode.W3076.searchReturnValue(msgstatus.globStatus.getWarnings()) != null))
+        if ((this.process == KnownTANProcess.PROCESS1 || this.process == KnownTANProcess.PROCESS2_STEP1) && (W3076.searchReturnValue(msgstatus.segStatus.getWarnings()) != null || W3076.searchReturnValue(msgstatus.globStatus.getWarnings()) != null))
         {
             HBCIUtils.log("found status code 3076, no SCA required",HBCIUtils.LOG_DEBUG);
             p.setPersistentData(AbstractPinTanPassport.KEY_PD_SCA,"true"); // Bewirkt, dass die TAN-Abfrage nicht erscheint

--- a/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
+++ b/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
@@ -203,7 +203,7 @@ public class GVTAN2Step extends HBCIJobImpl
             // Pruefen, ob die Bank eventuell ein 3040 gesendet hat - sie also noch weitere Daten braucht.
             // Das 3040 bezieht sich dann aber nicht auf unser HKTAN sondern auf den eigentlichen GV
             // In dem Fall muessen wir dem eigentlichen Task mitteilen, dass er erneut ausgefuehrt werden soll.
-            if (toInsCode(this.getHBCICode()).equals(segCode) && W3040.isIn(msgstatus.segStatus.getWarnings()) && this.task.redoAllowed())
+            if (segCode.equals(toInsCode(this.getHBCICode())) && W3040.isIn(msgstatus.segStatus.getWarnings()) && this.task.redoAllowed())
             {
                 HBCIUtils.log("found status code 3040, need to repeat task " + this.task.getHBCICode(),HBCIUtils.LOG_DEBUG);
                 HBCIUtils.log("Weitere Daten folgen",HBCIUtils.LOG_INFO);
@@ -212,7 +212,7 @@ public class GVTAN2Step extends HBCIJobImpl
 
             // Das ist das Response auf den eigentlichen GV - an den Task durchreichen
             // Muessen wir extra pruefen, weil das hier auch das HITAN sein koennte. Das schauen wir aber nicht an
-            if (toInsCode(this.task.getHBCICode()).equals(segCode))
+            if (segCode.equals(toInsCode(this.task.getHBCICode())))
             {
                 HBCIUtils.log("this is a response segment for the original task (" + this.task.getName() + ") - storing results in the original job",HBCIUtils.LOG_DEBUG);
                 this.task.fillJobResultFromTanJob(msgstatus, header, idx);

--- a/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
+++ b/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
@@ -205,7 +205,8 @@ public class GVTAN2Step extends HBCIJobImpl
             // Pruefen, ob die Bank eventuell ein 3040 gesendet hat - sie also noch weitere Daten braucht.
             // Das 3040 bezieht sich dann aber nicht auf unser HKTAN, sondern auf den eigentlichen GV.
             // In dem Fall muessen wir uns den eigentlichen Task für die erneute Ausfuehrung merken.
-            if (segCode.equals(toInsCode(this.getHBCICode())) && W3040.isIn(segS.getWarnings()) && this.task.redoAllowed())
+            if (W3040.isIn(segS.getWarnings()) &&
+                segCode.equals(toInsCode(this.getHBCICode())) && this.task.redoAllowed())
             {
                 HBCIUtils.log("found status code 3040, need to repeat task " + this.task.getHBCICode(),HBCIUtils.LOG_DEBUG);
                 HBCIUtils.log("Weitere Daten folgen",HBCIUtils.LOG_INFO);
@@ -228,7 +229,8 @@ public class GVTAN2Step extends HBCIJobImpl
 
         // SCA-Ausnahme checken. Wenn wir in der Auswertung des ersten HKTAN sind, pruefen wir, ob die Bank einen 3076 geschickt
         // hat. Wenn das der Fall ist, koennen wir das zweite HKTAN weglassen und muessen auch beim User keine TAN erfragen
-        if ((this.process == PROCESS1 || this.process == PROCESS2_STEP1) && (W3076.isIn(segS.getWarnings()) || W3076.isIn(globS.getWarnings())))
+        if ((this.process == PROCESS1 || this.process == PROCESS2_STEP1) &&
+            (W3076.isIn(segS.getWarnings()) || W3076.isIn(globS.getWarnings())))
         {
             HBCIUtils.log("found status code 3076, no SCA required",HBCIUtils.LOG_DEBUG);
             p.setPersistentData(AbstractPinTanPassport.KEY_PD_SCA,"true"); // Bewirkt, dass die TAN-Abfrage nicht erscheint

--- a/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
+++ b/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
@@ -203,7 +203,7 @@ public class GVTAN2Step extends HBCIJobImpl
             // Pruefen, ob die Bank eventuell ein 3040 gesendet hat - sie also noch weitere Daten braucht.
             // Das 3040 bezieht sich dann aber nicht auf unser HKTAN sondern auf den eigentlichen GV
             // In dem Fall muessen wir dem eigentlichen Task mitteilen, dass er erneut ausgefuehrt werden soll.
-            if (StringUtil.toInsCode(this.getHBCICode()).equals(segCode) && W3040.searchReturnValue(msgstatus.segStatus.getWarnings()) != null && this.task.redoAllowed())
+            if (StringUtil.toInsCode(this.getHBCICode()).equals(segCode) && W3040.isIn(msgstatus.segStatus.getWarnings()) && this.task.redoAllowed())
             {
                 HBCIUtils.log("found status code 3040, need to repeat task " + this.task.getHBCICode(),HBCIUtils.LOG_DEBUG);
                 HBCIUtils.log("Weitere Daten folgen",HBCIUtils.LOG_INFO);
@@ -230,7 +230,7 @@ public class GVTAN2Step extends HBCIJobImpl
         ///////////////////////////////////////////////////////////////////////
         // SCA-Ausnahme checken. Wenn wir in der Auswertung des ersten HKTAN sind, pruefen wir, ob die Bank einen 3076 geschickt
         // hat. Wenn das der Fall ist, koennen wir das zweite HKTAN weglassen und muessen auch beim User keine TAN erfragen
-        if ((this.process == PROCESS1 || this.process == PROCESS2_STEP1) && (W3076.searchReturnValue(msgstatus.segStatus.getWarnings()) != null || W3076.searchReturnValue(msgstatus.globStatus.getWarnings()) != null))
+        if ((this.process == PROCESS1 || this.process == PROCESS2_STEP1) && (W3076.isIn(msgstatus.segStatus.getWarnings()) || W3076.isIn(msgstatus.globStatus.getWarnings())))
         {
             HBCIUtils.log("found status code 3076, no SCA required",HBCIUtils.LOG_DEBUG);
             p.setPersistentData(AbstractPinTanPassport.KEY_PD_SCA,"true"); // Bewirkt, dass die TAN-Abfrage nicht erscheint

--- a/src/main/java/org/kapott/hbci/GV/HBCIJob.java
+++ b/src/main/java/org/kapott/hbci/GV/HBCIJob.java
@@ -191,7 +191,7 @@ public interface HBCIJob
 
     public void setParam(String paramName, Integer index, Date date);
 
-    /** Setzen eines Job-Parameters, bei dem ein Integer-Wert Da als Wert erwartet wird. Diese Methode
+    /** Setzen eines Job-Parameters, bei dem ein Integer-Wert als Wert erwartet wird. Diese Methode
      dient nur als Wrapper für {@link #setParam(String,String)}.
      @param paramName Name des zu setzenden Job-Parameters
      @param i Integer-Wert, der als Wert gesetzt werden soll */
@@ -212,7 +212,7 @@ public interface HBCIJob
     public void setParam(String paramName,String value);
 
     /** <p>Setzen eines Job-Parameters. Für alle Highlevel-Jobs ist in der Package-Beschreibung zum
-     Package <code>org.kapott.hbci.GV</code> eine Auflistung aller Jobs und deren Parameter zu finden.
+     Package {@link org.kapott.hbci.GV} eine Auflistung aller Jobs und deren Parameter zu finden.
      Für alle Lowlevel-Jobs kann eine Liste aller Parameter entweder mit dem Tool
      {@link org.kapott.hbci.tools.ShowLowlevelGVs} oder zur Laufzeit durch Aufruf
      der Methode {@link org.kapott.hbci.manager.HBCIHandler#getLowlevelJobParameterNames(String)} 

--- a/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
+++ b/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
@@ -857,7 +857,7 @@ public abstract class HBCIJobImpl
         return null;
     }
 
-    /* füllt das Objekt mit den Rückgabedaten, wenn der GV durch einen TAN Task
+    /** füllt das Objekt mit den Rückgabedaten, wenn der GV durch einen TAN Task
     gewrapped wurde und die GV-spezifischen Daten daraus übernommen werden müssen.
     Siehe dazu auch HBCIJobImpl::fillJobResult() 
     */
@@ -873,7 +873,7 @@ public abstract class HBCIJobImpl
         extractResults(status, header, contentCounter++);
     }
     
-    /* füllt das Objekt mit den Rückgabedaten. Dazu wird zuerst eine Liste aller
+    /** füllt das Objekt mit den Rückgabedaten. Dazu wird zuerst eine Liste aller
        Segmente erstellt, die Rückgabedaten für diesen Task enthalten. Anschließend
        werden die HBCI-Rückgabewerte (RetSegs) im outStore gespeichert. Danach werden
        die GV-spezifischen Daten im outStore abgelegt */
@@ -939,7 +939,7 @@ public abstract class HBCIJobImpl
         }
     }
     
-    /* wenn wenigstens ein HBCI-Rückgabewert für den aktuellen GV gefunden wurde,
+    /** wenn wenigstens ein HBCI-Rückgabewert für den aktuellen GV gefunden wurde,
        so werden im outStore zusätzlich die entsprechenden Dialog-Parameter
        gespeichert (Property @c basic.*) */
     private void saveBasicValues(Properties result,int ref)
@@ -962,7 +962,7 @@ public abstract class HBCIJobImpl
         }
     }
 
-    /*
+    /**
      * speichert die HBCI-Rückgabewerte für diesen GV im outStore ab. Dazu
      * werden alle RetSegs durchgesehen; diejenigen, die den aktuellen GV
      * betreffen, werden im @c data Property unter dem namen @c ret_i.*
@@ -990,7 +990,7 @@ public abstract class HBCIJobImpl
         jobResult.globStatus=status.globStatus;
     }
 
-    /* diese Methode wird i.d.R. durch abgeleitete GV-Klassen überschrieben, um die
+    /** diese Methode wird i.d.R. durch abgeleitete GV-Klassen überschrieben, um die
        Rückgabedaten in einem passenden Format abzuspeichern. Diese default-Implementation
        tut nichts */
     protected void extractResults(HBCIMsgStatus msgstatus,String header,int idx)

--- a/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
+++ b/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
@@ -1310,13 +1310,10 @@ public abstract class HBCIJobImpl
             return false; // Ne, noch nicht. Dann lassen wir das erstmal weg
         }
         
-        
         // SEPAInfo laden und darüber iterieren
         Properties props = handler.getLowlevelJobRestrictions("SEPAInfo");
         String value = props.getProperty("cannationalacc");
         HBCIUtils.log("cannationalacc=" + value,HBCIUtils.LOG_DEBUG);
         return value != null && value.equalsIgnoreCase("J");
     }
-    
-
 }

--- a/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
+++ b/src/main/java/org/kapott/hbci/GV/HBCIJobImpl.java
@@ -1020,8 +1020,7 @@ public abstract class HBCIJobImpl
         return passports.getMainPassport();
     }
     
-    private void _checkAccountCRC(String frontendname,
-    							  String blz,String number)
+    private void _checkAccountCRC(String frontendname, String blz,String number)
     {
         // pruefsummenberechnung nur wenn blz/kontonummer angegeben sind
         if (blz==null || number==null) {

--- a/src/main/java/org/kapott/hbci/dialog/KnownReturncode.java
+++ b/src/main/java/org/kapott/hbci/dialog/KnownReturncode.java
@@ -149,6 +149,11 @@ public enum KnownReturncode
         return null;
     }
 
+    public boolean isIn(HBCIRetVal[] rets)
+    {
+        return null != searchReturnValue(rets);
+    }
+
     /**
      * Sucht nach dem angegebenen Status-Code in den Rueckmeldungen und liefert den Code zurueck.
      * @param rets die Rueckmeldungen.


### PR DESCRIPTION
Im Zuge meiner Einarbeitung in den Code sind mir einige Dinge aufgefallen. Dieser Pullrequest konzentriert sich auf die Klasse `GVTAN2Step` und die folgenden Anpassungen daran:

- `Override`-Annotation
- Überarbeitung der Javadoc-Texte
- Lesbarkeit/ Verständlichkeit der Methode `extractResults`

Zusätzlich wurden in der Klasse `HBCIJobImpl` folgende Anpassungen vorgenommen:

- Sternchen sodass Kommentar zu Javadoc wird (und somit von IDE angezeigt wird)
- Zeilenumbruch bei Parameterliste einer Methode entfernt
- Leerzeilen entfernt