### PR TITLE
fix Postbank GetTanMethod

### DIFF
--- a/src/main/java/org/kapott/hbci/manager/HBCIHandler.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIHandler.java
@@ -159,8 +159,13 @@ public final class HBCIHandler
             this.passport.setParentHandlerData(this);
 
             if (!lazyInit) {
-                registerInstitute();
-                registerUser();
+                if (this.passport.isSpecialTreatmentForPostbank()) {
+                    registerUser();
+                    registerInstitute();
+                } else {
+                    registerInstitute();
+                    registerUser();
+                }
             }
 
             if (!passport.getHBCIVersion().equals(hbciversion)) {
@@ -201,8 +206,13 @@ public final class HBCIHandler
             try {
                 HBCIUtils.log("hbci thread: starting init()",HBCIUtils.LOG_DEBUG);
 
-                registerInstitute();
-                registerUser();
+                if (passport.isSpecialTreatmentForPostbank()) {
+                    registerUser();
+                    registerInstitute();
+                } else {
+                    registerInstitute();
+                    registerUser();
+                }
                 sync_main.setData("execStatus",null);
             } catch (Exception e) {
                 // im fehlerfall muss sicherheitshalber ein noch

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportInternal.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportInternal.java
@@ -47,6 +47,12 @@ public interface HBCIPassportInternal
     public String getSysId();
     public String getCID();
     public String getSysStatus();
+
+    /*
+      Besondere Behandlung für Postbank
+     */
+    default boolean isSpecialTreatmentForPostbank() { return false; }
+
     public String getProfileMethod();
     public String getProfileVersion();
 


### PR DESCRIPTION
Aktuell ist es unmöglich, bei der Postbank initial alle für den Benutzer verfügbaren TAN-Methoden zu bekommen; stattdessen werden alle von der Bank unterstützen Methoden aufgelistet. Dazu sind in AbstractPinTanPassport auch zahlreiche entsprechend kommentierten Workarounds eingebaut.

Durch einige kleinere Anpassungen ist es jedoch möglich, genau das alles zu umgehen und die korrekte Liste zu erhalten: man muss nur die Reihenfolge der Initialisierungen von Institut und User umkehren, und bei dem dann stattfindenden SYNC-Dialog auch OneStep erlauben.

Ich habe dazu entsprechend in die Passport-Klasse eine entsprechende Abfrage eingebaut, bei der für den Host "hbci.postbank.de" dieses Verhalten erzwungen wird. Diese Methode kann ggf. überschrieben werden kann, um das bisherige Verhalten auch weiterhin bei der Postbank zu erzwingen.

Unten die entsprechenden Debug-Logs eines auf https://github.com/hbci4j/hbci4java/blob/master/src/main/java/org/kapott/hbci/examples/UmsatzAbrufPinTan.java basierenden Test-Programms.

Insofern ist die Änderung mit einem Konto bei der der Postbank erfolgreich getestet; bei anderen Banken dürfte es keine Änderungen geben. Trotzdem wären weitere Tests natürlich grundsätzlich sinnvoll.

Konsequenterweise habe ich alle bisherigen Postbank-Workaround in AbstractPinTanPassport gelöscht, da sie jetzt nicht mehr notwendig sind, und den Code unnötig komplex machen.

bisher:
```
trying to load BLZ data
creating new instance of a PinTan passport
have to create new passport file
saving two step mechs: []
(re)checking selected pintan method using auto-determine strategy
saving current tan method: 999
searching supported passport formats
searching supported converters
  ConverterDDV
  ConverterPinTan
  ConverterAnonymous
  ConverterRSA
  ConverterRDHNew
saving passport data to C:\testpassport.dat
used time for encrypting passort into 801 bytes: 329 millis
passport data saved using AESFormat
saving file C:\testpassport.dat
renaming testpassport.dat_5551398971315410404 to testpassport.dat
new file now exists: C:\testpassport.dat
loading passport data from C:\testpassport.dat
used time for decrypting 801 bytes: 186 millis
passport data loaded using AESFormat
registering institute
Aktualisiere Bankparameter (BPD)
creating dialog DialogInitAnon, id 0, message number: 1, execution count: 0
creating new raw message DialogInitAnon
setting raw property DialogInitAnon.MsgHead.dialogid to "0"
setting raw property DialogInitAnon.MsgHead.msgnum to "1"
setting raw property DialogInitAnon.MsgTail.msgnum to "1"
setting raw property DialogInitAnon.Idn.KIK.blz to "10010010"
setting raw property DialogInitAnon.Idn.KIK.country to "DE"
setting raw property DialogInitAnon.ProcPrep.BPD to "0"
setting raw property DialogInitAnon.ProcPrep.UPD to "0"
setting raw property DialogInitAnon.ProcPrep.lang to "0"
setting raw property DialogInitAnon.ProcPrep.prodName to "36792786FA12F235F04647689"
setting raw property DialogInitAnon.ProcPrep.prodVersion to "3"
setting raw property DialogInitAnon.Idn.customerid to "9999999999"
setting raw property DialogInitAnon.Idn.sysid to "0"
setting raw property DialogInitAnon.Idn.sysStatus to "0"
HKTAN version: 6
needtanmedia: 
setting raw property DialogInitAnon.TAN2Step6 to "requested"
setting raw property DialogInitAnon.TAN2Step6.process to "4"
creating HKTAN for SCA [process : PROCESS2_STEP1, order code: HKIDN]
setting raw property DialogInitAnon.TAN2Step6.ordersegcode to "HKIDN"
setting raw property DialogInitAnon.TAN2Step6.OrderAccount.bic to ""
setting raw property DialogInitAnon.TAN2Step6.OrderAccount.iban to ""
setting raw property DialogInitAnon.TAN2Step6.OrderAccount.number to ""
setting raw property DialogInitAnon.TAN2Step6.OrderAccount.subnumber to ""
setting raw property DialogInitAnon.TAN2Step6.OrderAccount.KIK.blz to ""
setting raw property DialogInitAnon.TAN2Step6.OrderAccount.KIK.country to ""
setting raw property DialogInitAnon.TAN2Step6.orderhash to ""
setting raw property DialogInitAnon.TAN2Step6.orderref to ""
setting raw property DialogInitAnon.TAN2Step6.notlasttan to ""
setting raw property DialogInitAnon.TAN2Step6.challengeklass to ""
setting raw property DialogInitAnon.TAN2Step6.tanmedia to ""
sending message using dialog DialogInitAnon, id 0, message number: 1
generating raw message DialogInitAnon
sending message: HNHBK:1:3+000000000143+300+0+1'HKIDN:2:2+280:10010010+9999999999+0+0'HKVVB:3:3+0+0+0+36792786FA12F235F04647689+3'HKTAN:4:6+4+HKIDN'HNHBS:5:1+1'
communicating dialogid/msgnum 0/1
using filter: MIM (base64)
Verbinde mit https://hbci.postbank.de:443/banking/hbci.do und prüfe Zertifikat
using system socket factory
connecting to server
writing data to output stream
closing output stream
Warte auf Antwortdaten
found messagesize: 3696
received 1024 bytes
we still need 2672 bytes
received 128 bytes
we still need 2544 bytes
received 1024 bytes
we still need 1520 bytes
received 344 bytes
we still need 1176 bytes
received 1024 bytes
we still need 152 bytes
received 152 bytes
we still need 0 bytes
closing communication line
received message: HNHBK:1:3+000000002771+300+3821599565504000u5B4Xmy5MS.D11+1+3821599565504000u5B4Xmy5MS.D11:1'HIRMG:2:2+0020::Dialoginitialisierung erfolgreich.+0010::Nachricht entgegengenommen.'HIRMS:3:2:2+0020::Information fehlerfrei entgegengenommen.'HIRMS:4:2:3+1040::BPD nicht mehr aktuell. Aktuelle Version folgt.+1050::UPD nicht mehr aktuell. Aktuelle Version folgt.'HIBPA:5:3:3+16+280:10010010+Postbank Berlin+0+1+300+9999'HIKOM:6:4:3+280:10010010+1+3:https?://hbci.postbank.de/banking/hbci.do::MIM:1'HIPINS:7:1:3+1+1+0+5:50:6:::HKCCM:J:HKCDE:J:HKPAE:J:HKTAB:N:HKKAZ:N:HKCCS:J:HKCSL:J:HKDMC:J:DKPSA:J:HKPSA:J:HKEKA:N:HKCMB:N:HKSPA:N:HKCSE:J:HKTAN:N:HKCML:J:HKDSC:J:HKCDL:J:HKCDB:N:HKSAL:N:HKPRO:N:HKBME:J:HKCME:J:HKKAU:N:DKPAE:J:HKCSB:N:HKDME:J:HKCDN:J'DIPINS:8:1:3+1+1+HKCCM:J:HKCDE:J:HKTAB:N:HKKAZ:N:HKCCS:J:HKCSL:J:HKDMC:J:DKPSA:J:HKEKA:N:HKCMB:N:HKSPA:N:HKCSE:J:HKTAN:N:HKCML:J:HKDSC:J:HKCDL:J:HKCDB:N:HKSAL:N:HKPRO:N:HKBME:J:HKCME:J:HKKAU:N:DKPAE:J:HKCSB:N:HKDME:J:HKCDN:J'HIPAES:9:1:3+1+1+0'DIPAES:10:1:3+1+1'HIPSAS:11:1:3+1+1+0'DIPSAS:12:1:3+1+1'HITANS:13:6:3+1+1+0+N:N:0:910:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:911:2:HHD1.3.2:HHD:1.3.2:chipTAN manuell HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:912:2:HHD1.4OPT:HHDOPT1:1.4:chipTAN optisch HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:913:2:HHD1.4:HHD:1.4:chipTAN manuell HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:920:2:BestSign:BestSign::BestSign:6:2:BestSign:999:N:1:N:0:2:N:J:00:2:N:9:930:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:N:1:N:0:2:N:J:00:2:N:9'HITABS:14:2:3+1+1+0'HITABS:15:4:3+1+1+0'HIPROS:16:3:3+1+1'HISPAS:17:1:3+1+1+0+J:N:J:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.003.03:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.001.03:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.001.02'HIKAZS:18:5:3+1+1+90:N:N'HIKAZS:19:6:3+1+1+0+90:N:N'HISALS:20:5:3+1+1'HISALS:21:6:3+1+1+0'HIEKAS:22:3:3+1+1+0+J:N:N:3'HIKAUS:23:1:3+1+1+0'HICCSS:24:1:3+1+1+0'HICSES:25:1:3+1+1+0+0:180'HICSBS:26:1:3+1+1+1+N:J'HICSLS:27:1:3+1+1+1+J'HICDES:28:1:3+1+1+1+4:1:180:00:00:00:12345'HICDBS:29:1:3+1+1+1+N'HICDNS:30:1:3+1+1+1+0:1:180:J:J:J:J:J:J:J:J:J:00:00:00:12345'HICDLS:31:1:3+1+1+1+1:1:N:J'HICCMS:32:1:3+1+1+0+1000:J:J'HICMES:33:1:3+1+1+0+1:180:1000:J:J'HICMBS:34:1:3+1+1+1+N:J'HICMLS:35:1:3+1+1+1'HIDMES:36:1:3+1+1+0+1:30:1:30:1000:J:J'HIBMES:37:1:3+1+1+0+1:30:1:30:1000:J:J'HIDSCS:38:1:3+1+1+1+1:30:1:30::urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02'HIDMCS:39:1:3+1+1+1+1000:J:J:1:30:1:30::urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02'HIUPA:40:4:3+9999999999+1+0'HIUPD:41:6:3+9999999999::280:10010010++9999999999+++anonym'HITAN:42:6:4+4++noref+nochallenge'HNHBS:43:1+1'
trying to parse message as crypted message
message seems not to be encrypted; tring to parse it as DialogInitAnonRes message
received message after decryption: HNHBK:1:3+000000002771+300+3821599565504000u5B4Xmy5MS.D11+1+3821599565504000u5B4Xmy5MS.D11:1'HIRMG:2:2+0020::Dialoginitialisierung erfolgreich.+0010::Nachricht entgegengenommen.'HIRMS:3:2:2+0020::Information fehlerfrei entgegengenommen.'HIRMS:4:2:3+1040::BPD nicht mehr aktuell. Aktuelle Version folgt.+1050::UPD nicht mehr aktuell. Aktuelle Version folgt.'HIBPA:5:3:3+16+280:10010010+Postbank Berlin+0+1+300+9999'HIKOM:6:4:3+280:10010010+1+3:https?://hbci.postbank.de/banking/hbci.do::MIM:1'HIPINS:7:1:3+1+1+0+5:50:6:::HKCCM:J:HKCDE:J:HKPAE:J:HKTAB:N:HKKAZ:N:HKCCS:J:HKCSL:J:HKDMC:J:DKPSA:J:HKPSA:J:HKEKA:N:HKCMB:N:HKSPA:N:HKCSE:J:HKTAN:N:HKCML:J:HKDSC:J:HKCDL:J:HKCDB:N:HKSAL:N:HKPRO:N:HKBME:J:HKCME:J:HKKAU:N:DKPAE:J:HKCSB:N:HKDME:J:HKCDN:J'DIPINS:8:1:3+1+1+HKCCM:J:HKCDE:J:HKTAB:N:HKKAZ:N:HKCCS:J:HKCSL:J:HKDMC:J:DKPSA:J:HKEKA:N:HKCMB:N:HKSPA:N:HKCSE:J:HKTAN:N:HKCML:J:HKDSC:J:HKCDL:J:HKCDB:N:HKSAL:N:HKPRO:N:HKBME:J:HKCME:J:HKKAU:N:DKPAE:J:HKCSB:N:HKDME:J:HKCDN:J'HIPAES:9:1:3+1+1+0'DIPAES:10:1:3+1+1'HIPSAS:11:1:3+1+1+0'DIPSAS:12:1:3+1+1'HITANS:13:6:3+1+1+0+N:N:0:910:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:911:2:HHD1.3.2:HHD:1.3.2:chipTAN manuell HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:912:2:HHD1.4OPT:HHDOPT1:1.4:chipTAN optisch HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:913:2:HHD1.4:HHD:1.4:chipTAN manuell HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:920:2:BestSign:BestSign::BestSign:6:2:BestSign:999:N:1:N:0:2:N:J:00:2:N:9:930:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:N:1:N:0:2:N:J:00:2:N:9'HITABS:14:2:3+1+1+0'HITABS:15:4:3+1+1+0'HIPROS:16:3:3+1+1'HISPAS:17:1:3+1+1+0+J:N:J:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.003.03:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.001.03:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.001.02'HIKAZS:18:5:3+1+1+90:N:N'HIKAZS:19:6:3+1+1+0+90:N:N'HISALS:20:5:3+1+1'HISALS:21:6:3+1+1+0'HIEKAS:22:3:3+1+1+0+J:N:N:3'HIKAUS:23:1:3+1+1+0'HICCSS:24:1:3+1+1+0'HICSES:25:1:3+1+1+0+0:180'HICSBS:26:1:3+1+1+1+N:J'HICSLS:27:1:3+1+1+1+J'HICDES:28:1:3+1+1+1+4:1:180:00:00:00:12345'HICDBS:29:1:3+1+1+1+N'HICDNS:30:1:3+1+1+1+0:1:180:J:J:J:J:J:J:J:J:J:00:00:00:12345'HICDLS:31:1:3+1+1+1+1:1:N:J'HICCMS:32:1:3+1+1+0+1000:J:J'HICMES:33:1:3+1+1+0+1:180:1000:J:J'HICMBS:34:1:3+1+1+1+N:J'HICMLS:35:1:3+1+1+1'HIDMES:36:1:3+1+1+0+1:30:1:30:1000:J:J'HIBMES:37:1:3+1+1+0+1:30:1:30:1000:J:J'HIDSCS:38:1:3+1+1+1+1:30:1:30::urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02'HIDMCS:39:1:3+1+1+1+1000:J:J:1:30:1:30::urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02'HIUPA:40:4:3+9999999999+1+0'HIUPD:41:6:3+9999999999::280:10010010++9999999999+++anonym'HITAN:42:6:4+4++noref+nochallenge'HNHBS:43:1+1'
extracting data from received message
looking for a signature
message does not need a signature
looking if message is encrypted
new dialog-id: 3821599565504000u5B4Xmy5MS.D11
anonymous dialog, skip SCA response analysis
extracting BPD from results
installed new BPD with version 16
saving two step mechs: []
saving current tan method: 999
saving passport data to C:\testpassport.dat
used time for encrypting passort into 32673 bytes: 453 millis
passport data saved using AESFormat
saving file C:\testpassport.dat
deleting old file C:\testpassport.dat
renaming testpassport.dat_9114566241812602467 to testpassport.dat
new file now exists: C:\testpassport.dat
creating dialog DialogEndAnon, id 3821599565504000u5B4Xmy5MS.D11, message number: 2, execution count: 0
creating new raw message DialogEndAnon
setting raw property DialogEndAnon.MsgHead.dialogid to "3821599565504000u5B4Xmy5MS.D11"
setting raw property DialogEndAnon.MsgHead.msgnum to "2"
setting raw property DialogEndAnon.MsgTail.msgnum to "2"
setting raw property DialogEndAnon.DialogEndS.dialogid to "3821599565504000u5B4Xmy5MS.D11"
sending message using dialog DialogEndAnon, id 3821599565504000u5B4Xmy5MS.D11, message number: 2
generating raw message DialogEndAnon
sending message: HNHBK:1:3+000000000113+300+3821599565504000u5B4Xmy5MS.D11+2'HKEND:2:1+3821599565504000u5B4Xmy5MS.D11'HNHBS:3:1+2'
communicating dialogid/msgnum 3821599565504000u5B4Xmy5MS.D11/2
connecting to server
writing data to output stream
closing output stream
Warte auf Antwortdaten
found messagesize: 244
received 244 bytes
we still need 0 bytes
closing communication line
received message: HNHBK:1:3+000000000183+300+3821599565504000u5B4Xmy5MS.D11+2+3821599565504000u5B4Xmy5MS.D11:2'HIRMG:2:2+0010::Nachricht entgegengenommen.'HIRMS:3:2:2+0100::Dialog beendet.'HNHBS:4:1+2'
trying to parse message as crypted message
message seems not to be encrypted; tring to parse it as DialogEndAnonRes message
received message after decryption: HNHBK:1:3+000000000183+300+3821599565504000u5B4Xmy5MS.D11+2+3821599565504000u5B4Xmy5MS.D11:2'HIRMG:2:2+0010::Nachricht entgegengenommen.'HIRMS:3:2:2+0100::Dialog beendet.'HNHBS:4:1+2'
extracting data from received message
looking for a signature
message does not need a signature
looking if message is encrypted
new dialog-id: 3821599565504000u5B4Xmy5MS.D11
checking if requested hbci parameters are supported
(re)checking selected pintan method using auto-determine strategy
tan methods of institute: [910: chipTAN optisch HHD1.3.2, 911: chipTAN manuell HHD1.3.2, 912: chipTAN optisch HHD1.4, 913: chipTAN manuell HHD1.4, 920: BestSign, 930: mobileTAN]
tan methods for user: []
have no methods for user and institute doesn't allow one step method - asking user. available methods on institute: [910: chipTAN optisch HHD1.3.2, 911: chipTAN manuell HHD1.3.2, 912: chipTAN optisch HHD1.4, 913: chipTAN manuell HHD1.4, 920: BestSign, 930: mobileTAN]
Bitte TAN-Verfahren auswählen:
910:chipTAN optisch HHD1.3.2
911:chipTAN manuell HHD1.3.2
912:chipTAN optisch HHD1.4
913:chipTAN manuell HHD1.4
920:BestSign
930:mobileTAN
```

neu:
```
trying to load BLZ data
creating new instance of a PinTan passport
have to create new passport file
saving two step mechs: []
(re)checking selected pintan method using auto-determine strategy
saving current tan method: 999
searching supported passport formats
searching supported converters
  ConverterDDV
  ConverterPinTan
  ConverterAnonymous
  ConverterRSA
  ConverterRDHNew
saving passport data to C:\testpassport.dat
used time for encrypting passort into 801 bytes: 434 millis
passport data saved using AESFormat
saving file C:\testpassport.dat
renaming testpassport.dat_11976286825074093468 to testpassport.dat
new file now exists: C:\testpassport.dat
loading passport data from C:\testpassport.dat
used time for decrypting 801 bytes: 206 millis
passport data loaded using AESFormat
registering user
Rufe neue System-ID ab
checking whether passport is supported (but ignoring result)
passport supported: true
creating dialog Synch, id 0, message number: 1, execution count: 0
creating new raw message Synch
setting raw property Synch.MsgHead.dialogid to "0"
setting raw property Synch.MsgHead.msgnum to "1"
setting raw property Synch.MsgTail.msgnum to "1"
setting raw property Synch.Idn.KIK.blz to "10010010"
setting raw property Synch.Idn.KIK.country to "DE"
setting raw property Synch.ProcPrep.BPD to "0"
setting raw property Synch.ProcPrep.UPD to "0"
setting raw property Synch.ProcPrep.lang to "0"
setting raw property Synch.ProcPrep.prodName to "36792786FA12F235F04647689"
setting raw property Synch.ProcPrep.prodVersion to "3"
setting raw property Synch.Idn.customerid to "XXXXXX"
setting raw property Synch.Idn.sysid to "0"
setting raw property Synch.Idn.sysStatus to "1"
setting raw property Synch.Sync.mode to "0"
setting raw property Synch.ProcPrep.BPD to "0"
skipping HKTAN for dialog init, since we are using a one-step tan method
sending message using dialog Synch, id 0, message number: 1
generating raw message Synch
trying to insert signature
setting secfunc to 999
setting cid to 
setting role to 1
setting range to 1
setting keyblz to 10010010
setting keycountry to DE
setting keyuserid to XXXXXX
setting keynum to 0
setting keyversion to 0
setting sysid to 0
setting sigid to 1
setting sigalg to 10
setting sigmode to 16
setting hashalg to 999
saving two step mechs: []
saving current tan method: 999
saving passport data to C:\testpassport.dat
used time for encrypting passort into 801 bytes: 334 millis
passport data saved using AESFormat
saving file C:\testpassport.dat
deleting old file C:\testpassport.dat
renaming testpassport.dat_6640334534454280844 to testpassport.dat
new file now exists: C:\testpassport.dat
onestep method - checking GVs to decide whether or not we need a TAN
the job with the code HNSHK seems not to be allowed with PIN/TAN
the job with the code HKIDN seems not to be allowed with PIN/TAN
the job with the code HKVVB seems not to be allowed with PIN/TAN
the job with the code HKSYN seems not to be allowed with PIN/TAN
sending message: HNHBK:1:3+000000000272+300+0+1'HNSHK:2:4+PIN:1+999+721787101+1+1+1::0+1+1:20220206:120436+1:999:1+6:10:16+280:10010010:XXXXXX:S:0:0'HKIDN:3:2+280:10010010+XXXXXX+0+1'HKVVB:4:3+0+0+0+36792786FA12F235F04647689+3'HKSYN:5:3+0'HNSHA:6:2+721787101++XXXXXXXXXXXXXXX'HNHBS:7:1+1'
trying to encrypt message
creating new crypt factory
checking if crypt available in pool
no, creating new crypt
adding to used pool
crypt acquired
setting secfunc to 998
setting keytype to 5
setting blz to 10010010
setting country to DE
setting keyuserid to XXXXXX
setting keynum to 0
setting keyversion to 0
setting cid to 
setting sysId to 0
setting role to 1
setting alg to 13
setting mode to 2
setting compfunc to 0
encrypted message to be sent: HNHBK:1:3+000000000388+300+0+1'HNVSK:998:3+PIN:1+998+1+1::0+1:20220206:120436+2:2:13:@8@        :5:1+280:10010010:XXXXXX:V:0:0+0'HNVSD:999:1+@229@HNSHK:2:4+PIN:1+999+721787101+1+1+1::0+1+1:20220206:120436+1:999:1+6:10:16+280:10010010:XXXXXX:S:0:0'HKIDN:3:2+280:10010010+XXXXXX+0+1'HKVVB:4:3+0+0+0+36792786FA12F235F04647689+3'HKSYN:5:3+0'HNSHA:6:2+721787101++XXXXXXXXXXXXXXX''HNHBS:7:1+1'
communicating dialogid/msgnum 0/1
using filter: MIM (base64)
Verbinde mit https://hbci.postbank.de:443/banking/hbci.do und prüfe Zertifikat
using system socket factory
connecting to server
writing data to output stream
closing output stream
Warte auf Antwortdaten
found messagesize: 3976
received 1024 bytes
we still need 2952 bytes
received 1024 bytes
we still need 1928 bytes
received 1024 bytes
we still need 904 bytes
received 904 bytes
we still need 0 bytes
closing communication line
received message: HNHBK:1:3+000000002980+300+3821598282939000Iutab*l3F=.A11+1+3821598282939000Iutab*l3F=.A11:1'HNVSK:998:3+PIN:1+998+1+2::382159828304900089SDBN4S7A30GG+1:20220206:120443+2:2:13:@8@        :5:1+280:10010010:XXXXXX:V:0:0+0'HNVSD:999:1+@2728@HIRMG:2:2+0020::Dialoginitialisierung erfolgreich.+3075::Starke Authentifizierung ab dem 2019-09-08 erforderlich.:2019-09-08+3060::Teilweise liegen Warnungen/Hinweise vor.'HIRMS:3:2:3+0020::Information fehlerfrei entgegengenommen.'HIRMS:4:2:4+1040::BPD nicht mehr aktuell. Aktuelle Version folgt.+3920::Meldung unterstützter Ein- und Zwei-Schritt-Verfahren:920:930'HIRMS:5:2:5+0020::Auftrag ausgeführt.'HIBPA:6:3:4+16+280:10010010+Postbank Berlin+0+1+300+9999'HIKOM:7:4:4+280:10010010+1+3:https?://hbci.postbank.de/banking/hbci.do::MIM:1'HIPINS:8:1:4+1+1+0+5:50:6:::HKCDL:J:DKPAE:J:DKPSA:J:HKBME:J:HKPAE:J:HKCCM:J:HKCCS:J:HKCMB:N:HKCSE:J:HKSPA:N:HKPRO:N:HKKAU:N:HKCDN:J:HKSAL:N:HKCSL:J:HKDME:J:HKEKA:N:HKPSA:J:HKCDB:N:HKDMC:J:HKCDE:J:HKDSC:J:HKCSB:N:HKCME:J:HKKAZ:N:HKTAN:N:HKTAB:N:HKCML:J'DIPINS:9:1:4+1+1+HKCDL:J:DKPAE:J:DKPSA:J:HKBME:J:HKCCM:J:HKCCS:J:HKCMB:N:HKCSE:J:HKSPA:N:HKPRO:N:HKKAU:N:HKCDN:J:HKSAL:N:HKCSL:J:HKDME:J:HKEKA:N:HKCDB:N:HKDMC:J:HKCDE:J:HKDSC:J:HKCSB:N:HKCME:J:HKKAZ:N:HKTAN:N:HKTAB:N:HKCML:J'HIPAES:10:1:4+1+1+0'DIPAES:11:1:4+1+1'HIPSAS:12:1:4+1+1+0'DIPSAS:13:1:4+1+1'HITANS:14:6:4+1+1+0+N:N:0:910:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:911:2:HHD1.3.2:HHD:1.3.2:chipTAN manuell HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:912:2:HHD1.4OPT:HHDOPT1:1.4:chipTAN optisch HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:913:2:HHD1.4:HHD:1.4:chipTAN manuell HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:920:2:BestSign:BestSign::BestSign:6:2:BestSign:999:N:1:N:0:2:N:J:00:2:N:9:930:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:N:1:N:0:2:N:J:00:2:N:9'HITABS:15:2:4+1+1+0'HITABS:16:4:4+1+1+0'HIPROS:17:3:4+1+1'HISPAS:18:1:4+1+1+0+J:N:J:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.003.03:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.001.03:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.001.02'HIKAZS:19:5:4+1+1+90:N:N'HIKAZS:20:6:4+1+1+0+90:N:N'HISALS:21:5:4+1+1'HISALS:22:6:4+1+1+0'HIEKAS:23:3:4+1+1+0+J:N:N:3'HIKAUS:24:1:4+1+1+0'HICCSS:25:1:4+1+1+0'HICSES:26:1:4+1+1+0+0:180'HICSBS:27:1:4+1+1+1+N:J'HICSLS:28:1:4+1+1+1+J'HICDES:29:1:4+1+1+1+4:1:180:00:00:00:12345'HICDBS:30:1:4+1+1+1+N'HICDNS:31:1:4+1+1+1+0:1:180:J:J:J:J:J:J:J:J:J:00:00:00:12345'HICDLS:32:1:4+1+1+1+1:1:N:J'HICCMS:33:1:4+1+1+0+1000:J:J'HICMES:34:1:4+1+1+0+1:180:1000:J:J'HICMBS:35:1:4+1+1+1+N:J'HICMLS:36:1:4+1+1+1'HIDMES:37:1:4+1+1+0+1:30:1:30:1000:J:J'HIBMES:38:1:4+1+1+0+1:30:1:30:1000:J:J'HIDSCS:39:1:4+1+1+1+1:30:1:30::urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02'HIDMCS:40:1:4+1+1+1+1000:J:J:1:30:1:30::urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02'HISYN:41:4:5+382159828304900089SDBN4S7A30GG''HNHBS:42:1+1'
trying to parse message as crypted message
acquire crypt instance
checking if crypt available in pool
yes, initializing with handlerdata + message
adding to used pool
crypt acquired
decrypting using org.kapott.hbci.security.Crypt@cc43f62
decrypted message: HNHBK:1:3+000000002980+300+3821598282939000Iutab*l3F=.A11+1+3821598282939000Iutab*l3F=.A11:1'HIRMG:2:2+0020::Dialoginitialisierung erfolgreich.+3075::Starke Authentifizierung ab dem 2019-09-08 erforderlich.:2019-09-08+3060::Teilweise liegen Warnungen/Hinweise vor.'HIRMS:3:2:3+0020::Information fehlerfrei entgegengenommen.'HIRMS:4:2:4+1040::BPD nicht mehr aktuell. Aktuelle Version folgt.+3920::Meldung unterstützter Ein- und Zwei-Schritt-Verfahren:920:930'HIRMS:5:2:5+0020::Auftrag ausgeführt.'HIBPA:6:3:4+16+280:10010010+Postbank Berlin+0+1+300+9999'HIKOM:7:4:4+280:10010010+1+3:https?://hbci.postbank.de/banking/hbci.do::MIM:1'HIPINS:8:1:4+1+1+0+5:50:6:::HKCDL:J:DKPAE:J:DKPSA:J:HKBME:J:HKPAE:J:HKCCM:J:HKCCS:J:HKCMB:N:HKCSE:J:HKSPA:N:HKPRO:N:HKKAU:N:HKCDN:J:HKSAL:N:HKCSL:J:HKDME:J:HKEKA:N:HKPSA:J:HKCDB:N:HKDMC:J:HKCDE:J:HKDSC:J:HKCSB:N:HKCME:J:HKKAZ:N:HKTAN:N:HKTAB:N:HKCML:J'DIPINS:9:1:4+1+1+HKCDL:J:DKPAE:J:DKPSA:J:HKBME:J:HKCCM:J:HKCCS:J:HKCMB:N:HKCSE:J:HKSPA:N:HKPRO:N:HKKAU:N:HKCDN:J:HKSAL:N:HKCSL:J:HKDME:J:HKEKA:N:HKCDB:N:HKDMC:J:HKCDE:J:HKDSC:J:HKCSB:N:HKCME:J:HKKAZ:N:HKTAN:N:HKTAB:N:HKCML:J'HIPAES:10:1:4+1+1+0'DIPAES:11:1:4+1+1'HIPSAS:12:1:4+1+1+0'DIPSAS:13:1:4+1+1'HITANS:14:6:4+1+1+0+N:N:0:910:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:911:2:HHD1.3.2:HHD:1.3.2:chipTAN manuell HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:912:2:HHD1.4OPT:HHDOPT1:1.4:chipTAN optisch HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:913:2:HHD1.4:HHD:1.4:chipTAN manuell HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:920:2:BestSign:BestSign::BestSign:6:2:BestSign:999:N:1:N:0:2:N:J:00:2:N:9:930:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:N:1:N:0:2:N:J:00:2:N:9'HITABS:15:2:4+1+1+0'HITABS:16:4:4+1+1+0'HIPROS:17:3:4+1+1'HISPAS:18:1:4+1+1+0+J:N:J:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.003.03:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.001.03:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.001.02'HIKAZS:19:5:4+1+1+90:N:N'HIKAZS:20:6:4+1+1+0+90:N:N'HISALS:21:5:4+1+1'HISALS:22:6:4+1+1+0'HIEKAS:23:3:4+1+1+0+J:N:N:3'HIKAUS:24:1:4+1+1+0'HICCSS:25:1:4+1+1+0'HICSES:26:1:4+1+1+0+0:180'HICSBS:27:1:4+1+1+1+N:J'HICSLS:28:1:4+1+1+1+J'HICDES:29:1:4+1+1+1+4:1:180:00:00:00:12345'HICDBS:30:1:4+1+1+1+N'HICDNS:31:1:4+1+1+1+0:1:180:J:J:J:J:J:J:J:J:J:00:00:00:12345'HICDLS:32:1:4+1+1+1+1:1:N:J'HICCMS:33:1:4+1+1+0+1000:J:J'HICMES:34:1:4+1+1+0+1:180:1000:J:J'HICMBS:35:1:4+1+1+1+N:J'HICMLS:36:1:4+1+1+1'HIDMES:37:1:4+1+1+0+1:30:1:30:1000:J:J'HIBMES:38:1:4+1+1+0+1:30:1:30:1000:J:J'HIDSCS:39:1:4+1+1+1+1:30:1:30::urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02'HIDMCS:40:1:4+1+1+1+1000:J:J:1:30:1:30::urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02'HISYN:41:4:5+382159828304900089SDBN4S7A30GG'HNHBS:42:1+1'
decrypted
free crypt
crypt freed
rewriting message
applying rewriter RInvalidSegment
applying rewriter RWrongStatusSegOrder
applying rewriter RWrongSequenceNumbers
applying rewriter RMissingMsgRef
applying rewriter RHBCIVersion
applying rewriter RSigIdLeadingZero
applying rewriter RInvalidSuppHBCIVersion
applying rewriter RSecTypeTAN
applying rewriter RKUmsDelimiters
applying rewriter RKUmsEmptyBDateSets
rewriting done
decrypted message after rewriting: HNHBK:1:3+000000002980+300+3821598282939000Iutab*l3F=.A11+1+3821598282939000Iutab*l3F=.A11:1'HIRMG:2:2+0020::Dialoginitialisierung erfolgreich.+3075::Starke Authentifizierung ab dem 2019-09-08 erforderlich.:2019-09-08+3060::Teilweise liegen Warnungen/Hinweise vor.'HIRMS:3:2:3+0020::Information fehlerfrei entgegengenommen.'HIRMS:4:2:4+1040::BPD nicht mehr aktuell. Aktuelle Version folgt.+3920::Meldung unterstützter Ein- und Zwei-Schritt-Verfahren:920:930'HIRMS:5:2:5+0020::Auftrag ausgeführt.'HIBPA:6:3:4+16+280:10010010+Postbank Berlin+0+1+300+9999'HIKOM:7:4:4+280:10010010+1+3:https?://hbci.postbank.de/banking/hbci.do::MIM:1'HIPINS:8:1:4+1+1+0+5:50:6:::HKCDL:J:DKPAE:J:DKPSA:J:HKBME:J:HKPAE:J:HKCCM:J:HKCCS:J:HKCMB:N:HKCSE:J:HKSPA:N:HKPRO:N:HKKAU:N:HKCDN:J:HKSAL:N:HKCSL:J:HKDME:J:HKEKA:N:HKPSA:J:HKCDB:N:HKDMC:J:HKCDE:J:HKDSC:J:HKCSB:N:HKCME:J:HKKAZ:N:HKTAN:N:HKTAB:N:HKCML:J'DIPINS:9:1:4+1+1+HKCDL:J:DKPAE:J:DKPSA:J:HKBME:J:HKCCM:J:HKCCS:J:HKCMB:N:HKCSE:J:HKSPA:N:HKPRO:N:HKKAU:N:HKCDN:J:HKSAL:N:HKCSL:J:HKDME:J:HKEKA:N:HKCDB:N:HKDMC:J:HKCDE:J:HKDSC:J:HKCSB:N:HKCME:J:HKKAZ:N:HKTAN:N:HKTAB:N:HKCML:J'HIPAES:10:1:4+1+1+0'DIPAES:11:1:4+1+1'HIPSAS:12:1:4+1+1+0'DIPSAS:13:1:4+1+1'HITANS:14:6:4+1+1+0+N:N:0:910:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:911:2:HHD1.3.2:HHD:1.3.2:chipTAN manuell HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:912:2:HHD1.4OPT:HHDOPT1:1.4:chipTAN optisch HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:913:2:HHD1.4:HHD:1.4:chipTAN manuell HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:920:2:BestSign:BestSign::BestSign:6:2:BestSign:999:N:1:N:0:2:N:J:00:2:N:9:930:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:N:1:N:0:2:N:J:00:2:N:9'HITABS:15:2:4+1+1+0'HITABS:16:4:4+1+1+0'HIPROS:17:3:4+1+1'HISPAS:18:1:4+1+1+0+J:N:J:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.003.03:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.001.03:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.001.02'HIKAZS:19:5:4+1+1+90:N:N'HIKAZS:20:6:4+1+1+0+90:N:N'HISALS:21:5:4+1+1'HISALS:22:6:4+1+1+0'HIEKAS:23:3:4+1+1+0+J:N:N:3'HIKAUS:24:1:4+1+1+0'HICCSS:25:1:4+1+1+0'HICSES:26:1:4+1+1+0+0:180'HICSBS:27:1:4+1+1+1+N:J'HICSLS:28:1:4+1+1+1+J'HICDES:29:1:4+1+1+1+4:1:180:00:00:00:12345'HICDBS:30:1:4+1+1+1+N'HICDNS:31:1:4+1+1+1+0:1:180:J:J:J:J:J:J:J:J:J:00:00:00:12345'HICDLS:32:1:4+1+1+1+1:1:N:J'HICCMS:33:1:4+1+1+0+1000:J:J'HICMES:34:1:4+1+1+0+1:180:1000:J:J'HICMBS:35:1:4+1+1+1+N:J'HICMLS:36:1:4+1+1+1'HIDMES:37:1:4+1+1+0+1:30:1:30:1000:J:J'HIBMES:38:1:4+1+1+0+1:30:1:30:1000:J:J'HIDSCS:39:1:4+1+1+1+1:30:1:30::urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02'HIDMCS:40:1:4+1+1+1+1000:J:J:1:30:1:30::urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02'HISYN:41:4:5+382159828304900089SDBN4S7A30GG'HNHBS:42:1+1'
message to pe parsed: HNHBK:1:3+000000002980+300+3821598282939000Iutab*l3F=.A11+1+3821598282939000Iutab*l3F=.A11:1'HNVSK:998:3+PIN:1+998+1+2::382159828304900089SDBN4S7A30GG+1:20220206:120443+2:2:13:@8@        :5:1+280:10010010:XXXXXX:V:0:0+0'HNVSD:999:1+@2728@HIRMG:2:2+0020::Dialoginitialisierung erfolgreich.+3075::Starke Authentifizierung ab dem 2019-09-08 erforderlich.:2019-09-08+3060::Teilweise liegen Warnungen/Hinweise vor.'HIRMS:3:2:3+0020::Information fehlerfrei entgegengenommen.'HIRMS:4:2:4+1040::BPD nicht mehr aktuell. Aktuelle Version folgt.+3920::Meldung unterstützter Ein- und Zwei-Schritt-Verfahren:920:930'HIRMS:5:2:5+0020::Auftrag ausgeführt.'HIBPA:6:3:4+16+280:10010010+Postbank Berlin+0+1+300+9999'HIKOM:7:4:4+280:10010010+1+3:https?://hbci.postbank.de/banking/hbci.do::MIM:1'HIPINS:8:1:4+1+1+0+5:50:6:::HKCDL:J:DKPAE:J:DKPSA:J:HKBME:J:HKPAE:J:HKCCM:J:HKCCS:J:HKCMB:N:HKCSE:J:HKSPA:N:HKPRO:N:HKKAU:N:HKCDN:J:HKSAL:N:HKCSL:J:HKDME:J:HKEKA:N:HKPSA:J:HKCDB:N:HKDMC:J:HKCDE:J:HKDSC:J:HKCSB:N:HKCME:J:HKKAZ:N:HKTAN:N:HKTAB:N:HKCML:J'DIPINS:9:1:4+1+1+HKCDL:J:DKPAE:J:DKPSA:J:HKBME:J:HKCCM:J:HKCCS:J:HKCMB:N:HKCSE:J:HKSPA:N:HKPRO:N:HKKAU:N:HKCDN:J:HKSAL:N:HKCSL:J:HKDME:J:HKEKA:N:HKCDB:N:HKDMC:J:HKCDE:J:HKDSC:J:HKCSB:N:HKCME:J:HKKAZ:N:HKTAN:N:HKTAB:N:HKCML:J'HIPAES:10:1:4+1+1+0'DIPAES:11:1:4+1+1'HIPSAS:12:1:4+1+1+0'DIPSAS:13:1:4+1+1'HITANS:14:6:4+1+1+0+N:N:0:910:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:911:2:HHD1.3.2:HHD:1.3.2:chipTAN manuell HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:912:2:HHD1.4OPT:HHDOPT1:1.4:chipTAN optisch HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:913:2:HHD1.4:HHD:1.4:chipTAN manuell HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:920:2:BestSign:BestSign::BestSign:6:2:BestSign:999:N:1:N:0:2:N:J:00:2:N:9:930:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:N:1:N:0:2:N:J:00:2:N:9'HITABS:15:2:4+1+1+0'HITABS:16:4:4+1+1+0'HIPROS:17:3:4+1+1'HISPAS:18:1:4+1+1+0+J:N:J:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.003.03:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.001.03:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.001.02'HIKAZS:19:5:4+1+1+90:N:N'HIKAZS:20:6:4+1+1+0+90:N:N'HISALS:21:5:4+1+1'HISALS:22:6:4+1+1+0'HIEKAS:23:3:4+1+1+0+J:N:N:3'HIKAUS:24:1:4+1+1+0'HICCSS:25:1:4+1+1+0'HICSES:26:1:4+1+1+0+0:180'HICSBS:27:1:4+1+1+1+N:J'HICSLS:28:1:4+1+1+1+J'HICDES:29:1:4+1+1+1+4:1:180:00:00:00:12345'HICDBS:30:1:4+1+1+1+N'HICDNS:31:1:4+1+1+1+0:1:180:J:J:J:J:J:J:J:J:J:00:00:00:12345'HICDLS:32:1:4+1+1+1+1:1:N:J'HICCMS:33:1:4+1+1+0+1000:J:J'HICMES:34:1:4+1+1+0+1:180:1000:J:J'HICMBS:35:1:4+1+1+1+N:J'HICMLS:36:1:4+1+1+1'HIDMES:37:1:4+1+1+0+1:30:1:30:1000:J:J'HIBMES:38:1:4+1+1+0+1:30:1:30:1000:J:J'HIDSCS:39:1:4+1+1+1+1:30:1:30::urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02'HIDMCS:40:1:4+1+1+1+1000:J:J:1:30:1:30::urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02'HISYN:41:4:5+382159828304900089SDBN4S7A30GG''HNHBS:42:1+1'
received message after decryption: HNHBK:1:3+000000002980+300+3821598282939000Iutab*l3F=.A11+1+3821598282939000Iutab*l3F=.A11:1'HIRMG:2:2+0020::Dialoginitialisierung erfolgreich.+3075::Starke Authentifizierung ab dem 2019-09-08 erforderlich.:2019-09-08+3060::Teilweise liegen Warnungen/Hinweise vor.'HIRMS:3:2:3+0020::Information fehlerfrei entgegengenommen.'HIRMS:4:2:4+1040::BPD nicht mehr aktuell. Aktuelle Version folgt.+3920::Meldung unterstützter Ein- und Zwei-Schritt-Verfahren:920:930'HIRMS:5:2:5+0020::Auftrag ausgeführt.'HIBPA:6:3:4+16+280:10010010+Postbank Berlin+0+1+300+9999'HIKOM:7:4:4+280:10010010+1+3:https?://hbci.postbank.de/banking/hbci.do::MIM:1'HIPINS:8:1:4+1+1+0+5:50:6:::HKCDL:J:DKPAE:J:DKPSA:J:HKBME:J:HKPAE:J:HKCCM:J:HKCCS:J:HKCMB:N:HKCSE:J:HKSPA:N:HKPRO:N:HKKAU:N:HKCDN:J:HKSAL:N:HKCSL:J:HKDME:J:HKEKA:N:HKPSA:J:HKCDB:N:HKDMC:J:HKCDE:J:HKDSC:J:HKCSB:N:HKCME:J:HKKAZ:N:HKTAN:N:HKTAB:N:HKCML:J'DIPINS:9:1:4+1+1+HKCDL:J:DKPAE:J:DKPSA:J:HKBME:J:HKCCM:J:HKCCS:J:HKCMB:N:HKCSE:J:HKSPA:N:HKPRO:N:HKKAU:N:HKCDN:J:HKSAL:N:HKCSL:J:HKDME:J:HKEKA:N:HKCDB:N:HKDMC:J:HKCDE:J:HKDSC:J:HKCSB:N:HKCME:J:HKKAZ:N:HKTAN:N:HKTAB:N:HKCML:J'HIPAES:10:1:4+1+1+0'DIPAES:11:1:4+1+1'HIPSAS:12:1:4+1+1+0'DIPSAS:13:1:4+1+1'HITANS:14:6:4+1+1+0+N:N:0:910:2:HHD1.3.2OPT:HHDOPT1:1.3.2:chipTAN optisch HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:911:2:HHD1.3.2:HHD:1.3.2:chipTAN manuell HHD1.3.2:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:912:2:HHD1.4OPT:HHDOPT1:1.4:chipTAN optisch HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:913:2:HHD1.4:HHD:1.4:chipTAN manuell HHD1.4:6:1:Challenge:999:N:1:N:0:2:N:J:00:2:N:9:920:2:BestSign:BestSign::BestSign:6:2:BestSign:999:N:1:N:0:2:N:J:00:2:N:9:930:2:mobileTAN:mobileTAN::mobileTAN:6:2:mobileTAN:999:N:1:N:0:2:N:J:00:2:N:9'HITABS:15:2:4+1+1+0'HITABS:16:4:4+1+1+0'HIPROS:17:3:4+1+1'HISPAS:18:1:4+1+1+0+J:N:J:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.003.03:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.001.001.03:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02:urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.001.02'HIKAZS:19:5:4+1+1+90:N:N'HIKAZS:20:6:4+1+1+0+90:N:N'HISALS:21:5:4+1+1'HISALS:22:6:4+1+1+0'HIEKAS:23:3:4+1+1+0+J:N:N:3'HIKAUS:24:1:4+1+1+0'HICCSS:25:1:4+1+1+0'HICSES:26:1:4+1+1+0+0:180'HICSBS:27:1:4+1+1+1+N:J'HICSLS:28:1:4+1+1+1+J'HICDES:29:1:4+1+1+1+4:1:180:00:00:00:12345'HICDBS:30:1:4+1+1+1+N'HICDNS:31:1:4+1+1+1+0:1:180:J:J:J:J:J:J:J:J:J:00:00:00:12345'HICDLS:32:1:4+1+1+1+1:1:N:J'HICCMS:33:1:4+1+1+0+1000:J:J'HICMES:34:1:4+1+1+0+1:180:1000:J:J'HICMBS:35:1:4+1+1+1+N:J'HICMLS:36:1:4+1+1+1'HIDMES:37:1:4+1+1+0+1:30:1:30:1000:J:J'HIBMES:38:1:4+1+1+0+1:30:1:30:1000:J:J'HIDSCS:39:1:4+1+1+1+1:30:1:30::urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02'HIDMCS:40:1:4+1+1+1+1000:J:J:1:30:1:30::urn?:iso?:std?:iso?:20022?:tech?:xsd?:pain.008.003.02'HISYN:41:4:5+382159828304900089SDBN4S7A30GG'HNHBS:42:1+1'
extracting data from received message
looking for a signature
message has no signature
looking if message is encrypted
new dialog-id: 3821598282939000Iutab*l3F=.A11
autosecfunc: search for 3920 in response to detect allowed twostep secmechs
autosecfunc: found 3920 in response - updated list of allowed twostepmechs - old: [], new: [930, 920]
(re)checking selected pintan method using auto-determine strategy
tan methods of institute: []
tan methods for user: []
no tan method available for user, using: 999: Einschritt-Verfahren
extracting BPD from results
installed new BPD with version 16
extracting UPD from results
saving two step mechs: [930, 920]
saving current tan method: 999
saving passport data to C:\testpassport.dat
used time for encrypting passort into 32705 bytes: 386 millis
passport data saved using AESFormat
saving file C:\testpassport.dat
deleting old file C:\testpassport.dat
renaming testpassport.dat_17067129469952188157 to testpassport.dat
new file now exists: C:\testpassport.dat
new sys-id is 382159828304900089SDBN4S7A30GG
creating dialog DialogEnd, id 3821598282939000Iutab*l3F=.A11, message number: 2, execution count: 0
creating new raw message DialogEnd
setting raw property DialogEnd.MsgHead.dialogid to "3821598282939000Iutab*l3F=.A11"
setting raw property DialogEnd.MsgHead.msgnum to "2"
setting raw property DialogEnd.MsgTail.msgnum to "2"
setting raw property DialogEnd.DialogEndS.dialogid to "3821598282939000Iutab*l3F=.A11"
sending message using dialog DialogEnd, id 3821598282939000Iutab*l3F=.A11, message number: 2
generating raw message DialogEnd
trying to insert signature
setting secfunc to 999
setting cid to 
setting role to 1
setting range to 1
setting keyblz to 10010010
setting keycountry to DE
setting keyuserid to XXXXXX
setting keynum to 0
setting keyversion to 0
setting sysid to 382159828304900089SDBN4S7A30GG
setting sigid to 1
setting sigalg to 10
setting sigmode to 16
setting hashalg to 999
saving two step mechs: [930, 920]
saving current tan method: 999
saving passport data to C:\testpassport.dat
used time for encrypting passort into 32705 bytes: 240 millis
passport data saved using AESFormat
saving file C:\testpassport.dat
deleting old file C:\testpassport.dat
renaming testpassport.dat_3829224671086162366 to testpassport.dat
new file now exists: C:\testpassport.dat
onestep method - checking GVs to decide whether or not we need a TAN
sending message: HNHBK:1:3+000000000281+300+3821598282939000Iutab*l3F=.A11+2'HNSHK:2:4+PIN:1+999+316213782+1+1+1::382159828304900089SDBN4S7A30GG+1+1:20220206:120443+1:999:1+6:10:16+280:10010010:XXXXXX:S:0:0'HKEND:3:1+3821598282939000Iutab*l3F=.A11'HNSHA:4:2+316213782++XXXXXXXXXXXXXXX'HNHBS:5:1+2'
trying to encrypt message
checking if crypt available in pool
yes, initializing with handlerdata + message
adding to used pool
crypt acquired
setting secfunc to 998
setting keytype to 5
setting blz to 10010010
setting country to DE
setting keyuserid to XXXXXX
setting keynum to 0
setting keyversion to 0
setting cid to 
setting sysId to 382159828304900089SDBN4S7A30GG
setting role to 1
setting alg to 13
setting mode to 2
setting compfunc to 0
encrypted message to be sent: HNHBK:1:3+000000000426+300+3821598282939000Iutab*l3F=.A11+2'HNVSK:998:3+PIN:1+998+1+1::382159828304900089SDBN4S7A30GG+1:20220206:120443+2:2:13:@8@        :5:1+280:10010010:XXXXXX:V:0:0+0'HNVSD:999:1+@209@HNSHK:2:4+PIN:1+999+316213782+1+1+1::382159828304900089SDBN4S7A30GG+1+1:20220206:120443+1:999:1+6:10:16+280:10010010:XXXXXX:S:0:0'HKEND:3:1+3821598282939000Iutab*l3F=.A11'HNSHA:4:2+316213782++XXXXXXXXXXXXXXX''HNHBS:5:1+2'
communicating dialogid/msgnum 3821598282939000Iutab*l3F=.A11/2
connecting to server
writing data to output stream
closing output stream
Warte auf Antwortdaten
found messagesize: 436
received 436 bytes
we still need 0 bytes
closing communication line
received message: HNHBK:1:3+000000000327+300+3821598282939000Iutab*l3F=.A11+2+3821598282939000Iutab*l3F=.A11:2'HNVSK:998:3+PIN:1+998+1+2::382159828304900089SDBN4S7A30GG+1:20220206:120444+2:2:13:@8@        :5:1+280:10010010:XXXXXX:V:0:0+0'HNVSD:999:1+@78@HIRMG:2:2+0010::Nachricht entgegengenommen.'HIRMS:3:2:3+0100::Dialog beendet.''HNHBS:4:1+2'
trying to parse message as crypted message
acquire crypt instance
checking if crypt available in pool
yes, initializing with handlerdata + message
adding to used pool
crypt acquired
decrypting using org.kapott.hbci.security.Crypt@cc43f62
decrypted message: HNHBK:1:3+000000000327+300+3821598282939000Iutab*l3F=.A11+2+3821598282939000Iutab*l3F=.A11:2'HIRMG:2:2+0010::Nachricht entgegengenommen.'HIRMS:3:2:3+0100::Dialog beendet.'HNHBS:4:1+2'
decrypted
free crypt
crypt freed
rewriting message
applying rewriter RInvalidSegment
applying rewriter RWrongStatusSegOrder
applying rewriter RWrongSequenceNumbers
applying rewriter RMissingMsgRef
applying rewriter RHBCIVersion
applying rewriter RSigIdLeadingZero
applying rewriter RInvalidSuppHBCIVersion
applying rewriter RSecTypeTAN
applying rewriter RKUmsDelimiters
applying rewriter RKUmsEmptyBDateSets
rewriting done
decrypted message after rewriting: HNHBK:1:3+000000000327+300+3821598282939000Iutab*l3F=.A11+2+3821598282939000Iutab*l3F=.A11:2'HIRMG:2:2+0010::Nachricht entgegengenommen.'HIRMS:3:2:3+0100::Dialog beendet.'HNHBS:4:1+2'
message to pe parsed: HNHBK:1:3+000000000327+300+3821598282939000Iutab*l3F=.A11+2+3821598282939000Iutab*l3F=.A11:2'HNVSK:998:3+PIN:1+998+1+2::382159828304900089SDBN4S7A30GG+1:20220206:120444+2:2:13:@8@        :5:1+280:10010010:XXXXXX:V:0:0+0'HNVSD:999:1+@78@HIRMG:2:2+0010::Nachricht entgegengenommen.'HIRMS:3:2:3+0100::Dialog beendet.''HNHBS:4:1+2'
received message after decryption: HNHBK:1:3+000000000327+300+3821598282939000Iutab*l3F=.A11+2+3821598282939000Iutab*l3F=.A11:2'HIRMG:2:2+0010::Nachricht entgegengenommen.'HIRMS:3:2:3+0100::Dialog beendet.'HNHBS:4:1+2'
extracting data from received message
looking for a signature
message has no signature
looking if message is encrypted
new dialog-id: 3821598282939000Iutab*l3F=.A11
autosecfunc: search for 3920 in response to detect allowed twostep secmechs
trying to fetch TAN media names [skip sca: true]
creating dialog DialogInit, id 0, message number: 1, execution count: 0
creating new raw message DialogInit
setting raw property DialogInit.MsgHead.dialogid to "0"
setting raw property DialogInit.MsgHead.msgnum to "1"
setting raw property DialogInit.MsgTail.msgnum to "1"
setting raw property DialogInit.Idn.KIK.blz to "10010010"
setting raw property DialogInit.Idn.KIK.country to "DE"
setting raw property DialogInit.ProcPrep.BPD to "16"
setting raw property DialogInit.ProcPrep.UPD to "0"
setting raw property DialogInit.ProcPrep.lang to "1"
setting raw property DialogInit.ProcPrep.prodName to "36792786FA12F235F04647689"
setting raw property DialogInit.ProcPrep.prodVersion to "3"
setting raw property DialogInit.Idn.customerid to "XXXXXX"
setting raw property DialogInit.Idn.sysid to "382159828304900089SDBN4S7A30GG"
setting raw property DialogInit.Idn.sysStatus to "1"
skipping HKTAN for dialog init, since we are using a one-step tan method
sending message using dialog DialogInit, id 0, message number: 1
generating raw message DialogInit
trying to insert signature
setting secfunc to 999
setting cid to 
setting role to 1
setting range to 1
setting keyblz to 10010010
setting keycountry to DE
setting keyuserid to XXXXXX
setting keynum to 0
setting keyversion to 0
setting sysid to 382159828304900089SDBN4S7A30GG
setting sigid to 1
setting sigalg to 10
setting sigmode to 16
setting hashalg to 999
saving two step mechs: [930, 920]
saving current tan method: 999
saving passport data to C:\testpassport.dat
used time for encrypting passort into 32705 bytes: 305 millis
passport data saved using AESFormat
saving file C:\testpassport.dat
deleting old file C:\testpassport.dat
renaming testpassport.dat_8306574073013891171 to testpassport.dat
new file now exists: C:\testpassport.dat
onestep method - checking GVs to decide whether or not we need a TAN
sending message: HNHBK:1:3+000000000321+300+0+1'HNSHK:2:4+PIN:1+999+2055276565+1+1+1::382159828304900089SDBN4S7A30GG+1+1:20220206:120444+1:999:1+6:10:16+280:10010010:XXXXXX:S:0:0'HKIDN:3:2+280:10010010+XXXXXX+382159828304900089SDBN4S7A30GG+1'HKVVB:4:3+16+0+1+36792786FA12F235F04647689+3'HNSHA:5:2+2055276565++XXXXXXXXXXXXXXX'HNHBS:6:1+1'
trying to encrypt message
checking if crypt available in pool
yes, initializing with handlerdata + message
adding to used pool
crypt acquired
setting secfunc to 998
setting keytype to 5
setting blz to 10010010
setting country to DE
setting keyuserid to XXXXXX
setting keynum to 0
setting keyversion to 0
setting cid to 
setting sysId to 382159828304900089SDBN4S7A30GG
setting role to 1
setting alg to 13
setting mode to 2
setting compfunc to 0
encrypted message to be sent: HNHBK:1:3+000000000466+300+0+1'HNVSK:998:3+PIN:1+998+1+1::382159828304900089SDBN4S7A30GG+1:20220206:120444+2:2:13:@8@        :5:1+280:10010010:XXXXXX:V:0:0+0'HNVSD:999:1+@278@HNSHK:2:4+PIN:1+999+2055276565+1+1+1::382159828304900089SDBN4S7A30GG+1+1:20220206:120444+1:999:1+6:10:16+280:10010010:XXXXXX:S:0:0'HKIDN:3:2+280:10010010+XXXXXX+382159828304900089SDBN4S7A30GG+1'HKVVB:4:3+16+0+1+36792786FA12F235F04647689+3'HNSHA:5:2+2055276565++XXXXXXXXXXXXXXX''HNHBS:6:1+1'
communicating dialogid/msgnum 0/1
using filter: MIM (base64)
Verbinde mit https://hbci.postbank.de:443/banking/hbci.do und prüfe Zertifikat
using system socket factory
connecting to server
writing data to output stream
closing output stream
Warte auf Antwortdaten
found messagesize: 748
received 748 bytes
we still need 0 bytes
closing communication line
received message: HNHBK:1:3+000000000561+300+38215982849020002efzuVCPqW.A11+1+38215982849020002efzuVCPqW.A11:1'HNVSK:998:3+PIN:1+998+1+2::382159828304900089SDBN4S7A30GG+1:20220206:120445+2:2:13:@8@        :5:1+280:10010010:XXXXXX:V:0:0+0'HNVSD:999:1+@311@HIRMG:2:2+0020::Dialoginitialisierung erfolgreich.+3075::Starke Authentifizierung ab dem 2019-09-08 erforderlich.:2019-09-08+3060::Teilweise liegen Warnungen/Hinweise vor.'HIRMS:3:2:3+0020::Information fehlerfrei entgegengenommen.'HIRMS:4:2:4+3920::Meldung unterstützter Ein- und Zwei-Schritt-Verfahren:920:930''HNHBS:5:1+1'
trying to parse message as crypted message
acquire crypt instance
checking if crypt available in pool
yes, initializing with handlerdata + message
adding to used pool
crypt acquired
decrypting using org.kapott.hbci.security.Crypt@cc43f62
decrypted message: HNHBK:1:3+000000000561+300+38215982849020002efzuVCPqW.A11+1+38215982849020002efzuVCPqW.A11:1'HIRMG:2:2+0020::Dialoginitialisierung erfolgreich.+3075::Starke Authentifizierung ab dem 2019-09-08 erforderlich.:2019-09-08+3060::Teilweise liegen Warnungen/Hinweise vor.'HIRMS:3:2:3+0020::Information fehlerfrei entgegengenommen.'HIRMS:4:2:4+3920::Meldung unterstützter Ein- und Zwei-Schritt-Verfahren:920:930'HNHBS:5:1+1'
decrypted
free crypt
crypt freed
rewriting message
applying rewriter RInvalidSegment
applying rewriter RWrongStatusSegOrder
applying rewriter RWrongSequenceNumbers
applying rewriter RMissingMsgRef
applying rewriter RHBCIVersion
applying rewriter RSigIdLeadingZero
applying rewriter RInvalidSuppHBCIVersion
applying rewriter RSecTypeTAN
applying rewriter RKUmsDelimiters
applying rewriter RKUmsEmptyBDateSets
rewriting done
decrypted message after rewriting: HNHBK:1:3+000000000561+300+38215982849020002efzuVCPqW.A11+1+38215982849020002efzuVCPqW.A11:1'HIRMG:2:2+0020::Dialoginitialisierung erfolgreich.+3075::Starke Authentifizierung ab dem 2019-09-08 erforderlich.:2019-09-08+3060::Teilweise liegen Warnungen/Hinweise vor.'HIRMS:3:2:3+0020::Information fehlerfrei entgegengenommen.'HIRMS:4:2:4+3920::Meldung unterstützter Ein- und Zwei-Schritt-Verfahren:920:930'HNHBS:5:1+1'
message to pe parsed: HNHBK:1:3+000000000561+300+38215982849020002efzuVCPqW.A11+1+38215982849020002efzuVCPqW.A11:1'HNVSK:998:3+PIN:1+998+1+2::382159828304900089SDBN4S7A30GG+1:20220206:120445+2:2:13:@8@        :5:1+280:10010010:XXXXXX:V:0:0+0'HNVSD:999:1+@311@HIRMG:2:2+0020::Dialoginitialisierung erfolgreich.+3075::Starke Authentifizierung ab dem 2019-09-08 erforderlich.:2019-09-08+3060::Teilweise liegen Warnungen/Hinweise vor.'HIRMS:3:2:3+0020::Information fehlerfrei entgegengenommen.'HIRMS:4:2:4+3920::Meldung unterstützter Ein- und Zwei-Schritt-Verfahren:920:930''HNHBS:5:1+1'
received message after decryption: HNHBK:1:3+000000000561+300+38215982849020002efzuVCPqW.A11+1+38215982849020002efzuVCPqW.A11:1'HIRMG:2:2+0020::Dialoginitialisierung erfolgreich.+3075::Starke Authentifizierung ab dem 2019-09-08 erforderlich.:2019-09-08+3060::Teilweise liegen Warnungen/Hinweise vor.'HIRMS:3:2:3+0020::Information fehlerfrei entgegengenommen.'HIRMS:4:2:4+3920::Meldung unterstützter Ein- und Zwei-Schritt-Verfahren:920:930'HNHBS:5:1+1'
extracting data from received message
looking for a signature
message has no signature
looking if message is encrypted
new dialog-id: 38215982849020002efzuVCPqW.A11
autosecfunc: search for 3920 in response to detect allowed twostep secmechs
(re)checking selected pintan method using auto-determine strategy
tan methods of institute: [910: chipTAN optisch HHD1.3.2, 911: chipTAN manuell HHD1.3.2, 912: chipTAN optisch HHD1.4, 913: chipTAN manuell HHD1.4, 920: BestSign, 930: mobileTAN]
tan methods for user: [920: BestSign, 930: mobileTAN]
asking user what tan method to use. available methods: [920: BestSign, 930: mobileTAN]
Bitte TAN-Verfahren auswählen:
920:BestSign
930:mobileTAN
```