### PR TITLE
Umstellung von HBCIPassportRAH10.init() auf protected

### DIFF
--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportRAH10.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportRAH10.java
@@ -118,7 +118,7 @@ public class HBCIPassportRAH10 extends AbstractHBCIPassport implements InitLette
         init(data);
     }
 
-    private void init(PassportData data) {
+    protected void init(PassportData data) {
         this.data = data;
 
         // Wir uebernehmen nur die Daten in die Basis-Klasse, die dort vorgehalten werden.


### PR DESCRIPTION
Umstellung von HBCIPassportRAH10.init() auf protected, um die Nutzung in überschreibenden Klassen zu ermöglichen