### PR TITLE
Einbeziehung der Subnumber als Suchkriterium für ein Konto

### DIFF
--- a/src/main/java/org/kapott/hbci/passport/AbstractHBCIPassport.java
+++ b/src/main/java/org/kapott/hbci/passport/AbstractHBCIPassport.java
@@ -288,8 +288,10 @@ public abstract class AbstractHBCIPassport
     public final void fillAccountInfo(Konto account)
     {
         String  number     = HBCIUtilsInternal.stripLeadingZeroes(account.number);
+        String  subNumber  = HBCIUtilsInternal.stripLeadingZeroes(account.subnumber);
         String  iban       = HBCIUtilsInternal.stripLeadingZeroes(account.iban);
         boolean haveNumber = (number!=null && number.length()!=0);
+        boolean haveSubNumber = (subNumber!=null && subNumber.length()!=0);
         boolean haveIBAN   = (iban!=null && iban.length()!=0);
         
         Konto[] accounts = getAccounts();
@@ -297,9 +299,11 @@ public abstract class AbstractHBCIPassport
         for (int i=0;i<accounts.length;i++)
         {
             String temp_number = HBCIUtilsInternal.stripLeadingZeroes(accounts[i].number);
+            String temp_subnumber = HBCIUtilsInternal.stripLeadingZeroes(accounts[i].subnumber);
             String temp_iban = HBCIUtilsInternal.stripLeadingZeroes(accounts[i].iban);
             
-            if (haveNumber && number.equals(temp_number) || haveIBAN && iban.equals(temp_iban)) 
+            if ((haveNumber && number.equals(temp_number) && (!haveSubNumber || subNumber.equals(temp_subnumber)))
+                    || (haveIBAN && iban.equals(temp_iban)))
             {
                 if (accounts[i].blz != null        && accounts[i].blz.length() > 0)        account.blz=accounts[i].blz;
                 if (accounts[i].country != null    && accounts[i].country.length() > 0)    account.country=accounts[i].country;


### PR DESCRIPTION
Da manche Banken (z.B. die Commerzbank) für das Girokonto und das Depot die selbe Number verwenden, muss zusätzlich die Subnumber als Suchkriterium mit verwendet werden; ansonsten ist es nicht möglich das Depot zu selektieren