### PR TITLE
HBCIHandler um AutoClosable interface erweitern

### DIFF
--- a/src/main/java/org/kapott/hbci/manager/HBCIHandler.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIHandler.java
@@ -82,7 +82,7 @@ HBCIExecStatus status=handle.execute();
 handle.close();
 </pre> */
 public final class HBCIHandler
-	implements IHandlerData
+	implements IHandlerData, AutoCloseable
 {
     public final static int REFRESH_BPD=1;
     public final static int REFRESH_UPD=2;


### PR DESCRIPTION
Durch Implementieren des Autoclosable interfaces kann der HBCIHandler mit einem try-with-resources Statement genutzt werden:

```
try (HBCIHandler handler = new HBCIHandler(...)) {
    handler.newJob("");
}
```