### PR TITLE
Decoupled-Verfahren status refresh

### DIFF
--- a/src/main/java/org/kapott/hbci/callback/HBCICallback.java
+++ b/src/main/java/org/kapott/hbci/callback/HBCICallback.java
@@ -352,9 +352,20 @@ public interface HBCICallback
     public final static int NEED_PT_QRTAN=34;
 
     /**
-     * Ursache des Callback-Aufrufes: PushTAN 2.0 nötig.
+     * Ursache des Callback-Aufrufes: Das Decoupled Verfahren wird verwendet und eine Statusabfrage muss
+     * durchgeführt werden, um zu prüfen, ob der Kunde den Prozess bestätigt hat.
      **/
     public final static int NEED_PT_DECOUPLED=35;
+
+    /**
+     * Ursache des Callback-Aufrufes: Das Decoupled Verfahren wird verwendet und eine <em>weitere</em> Statusabfrage
+     * muss durchgeführt werden, um zu prüfen, ob der Kunde den Prozess bestätigt hat.
+     * Kann nur nach <code>NEED_PT_DECOUPLED</code> auftreten, wenn der Kunde den Prozess immer noch nicht bestätigt hat.
+     * In <code>retData</code> steht die minimale Wartezeit vor der Statusabfrage in Sekunden.
+     * Sollte der callback vor Ablauf dieser Zeit returned werden, pausiert <em>HBCI4Java</em> den Thread
+     * für die restliche Zeit.
+     **/
+    public final static int NEED_PT_DECOUPLED_RETRY=36;
 
     /** <p>Ursache des Callbacks: falsche PIN eingegeben */
     public final static int WRONG_PIN=40;

--- a/src/main/java/org/kapott/hbci/dialog/KnownReturncode.java
+++ b/src/main/java/org/kapott/hbci/dialog/KnownReturncode.java
@@ -51,6 +51,11 @@ public enum KnownReturncode
      * Die Liste der zugelassenen Zweischritt-Verfahren.
      */
     W3920("3920"),
+
+    /**
+     * Starke Kundenauthentifizierung noch ausstehend (DECOUPLED Verfahren).
+     */
+    W3956("3956"),
     
     /**
      * Signatur falsch (generisch)

--- a/src/main/java/org/kapott/hbci/manager/HBCIUtilsInternal.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIUtilsInternal.java
@@ -26,14 +26,18 @@ import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.MessageFormat;
 import java.util.Hashtable;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.MissingResourceException;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.ResourceBundle;
+import java.util.stream.Collectors;
 
 import org.kapott.hbci.callback.HBCICallback;
 import org.kapott.hbci.passport.HBCIPassport;
+import org.kapott.hbci.tools.ParameterFinder;
 
 public class HBCIUtilsInternal
 {
@@ -258,6 +262,35 @@ public class HBCIUtilsInternal
     	}
     	
     	return ret;
+    }
+
+    /**
+     * Hilfs-methode um eine numerische property anhand einer Query zu finden.
+     * @param properties Die Properties.
+     * @param query Die Query, um die property zu finden.
+     * @param useMinimum Ob im Falle von mehreren Werten das Minimum oder Maximum returned werden soll.
+     * @return Die property als integer, oder null, falls nicht gefunden.
+     */
+    public static Integer getIntegerProperty(Properties properties, ParameterFinder.Query query, boolean useMinimum) {
+        List<Integer> values = ParameterFinder.findAll(properties, query).values()
+                .stream()
+                .map(value -> {
+                    try {
+                        return Integer.parseInt(value.toString());
+                    } catch (NumberFormatException e) {
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        if (values.isEmpty()) {
+            return null;
+        }
+        if (useMinimum) {
+            return values.stream().min(Integer::compareTo).orElse(null);
+        } else {
+            return values.stream().max(Integer::compareTo).orElse(null);
+        }
     }
     
 }

--- a/src/main/java/org/kapott/hbci/passport/AbstractPinTanPassport.java
+++ b/src/main/java/org/kapott/hbci/passport/AbstractPinTanPassport.java
@@ -732,6 +732,39 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
       
       return ParameterFinder.findAll(bpd,ParameterFinder.Query.BPD_PINTAN_CAN1STEP).containsValue("J");
     }
+
+    /**
+     * Für das Decoupled Verfahren, liefert die minimale Zeit vor dem ersten refresh.
+     * @return Die minimale Zeit vor dem ersten Decoupled refresh.
+     */
+    public Integer getMinimumTimeBeforeFirstDecoupledRefresh() {
+        final Properties bpd = this.getBPD();
+        if (bpd == null)
+            return null;
+        return HBCIUtilsInternal.getIntegerProperty(bpd, Query.BPD_DECOUPLED_TIME_BEFORE_FIRST_STATUS_REQUEST, false);
+    }
+
+    /**
+     * Für das Decoupled Verfahren, liefert die minimale Zeit vor weiteren refreshes.
+     * @return Die minimale Zeit vor weiteren Decoupled refreshes.
+     */
+    public Integer getMinimumTimeBeforeNextDecoupledRefresh() {
+        final Properties bpd = this.getBPD();
+        if (bpd == null)
+            return null;
+        return HBCIUtilsInternal.getIntegerProperty(bpd, Query.BPD_DECOUPLED_TIME_BEFORE_NEXT_STATUS_REQUEST, false);
+    }
+
+    /**
+     * Für das Decoupled Verfahren, liefert die maximale Anzahl von refreshes.
+     * @return Die maximale Anzahl von Decoupled refreshes.
+     */
+    public Integer getDecoupledMaxRefreshes() {
+        final Properties bpd = this.getBPD();
+        if (bpd == null)
+            return null;
+        return HBCIUtilsInternal.getIntegerProperty(bpd, Query.BPD_DECOUPLED_MAX_STATUS_REQUESTS, true);
+    }
     
     /** Kann vor <code>new HBCIHandler()</code> aufgerufen werden, um zu
      * erzwingen, dass die Liste der unterstützten PIN/TAN-Sicherheitsverfahren

--- a/src/main/java/org/kapott/hbci/tools/ParameterFinder.java
+++ b/src/main/java/org/kapott/hbci/tools/ParameterFinder.java
@@ -54,9 +54,9 @@ public class ParameterFinder
          *  2. Minimale Zeit vor weiteren refreshes (Sekunden).
          *  3. Maximale Anzahl von refreshes.
          */
-        public final static Query BPD_DECOUPLED_TIME_BEFORE_FIRST_STATUS_REQUEST = new Query("Params_*.TAN2StepPar7.ParTAN2Step*.TAN2StepParams_*.decoupled_time_before_first_status_request",false);
-        public final static Query BPD_DECOUPLED_TIME_BEFORE_NEXT_STATUS_REQUEST = new Query("Params_*.TAN2StepPar7.ParTAN2Step*.TAN2StepParams_*.decoupled_time_before_next_status_request",false);
-        public final static Query BPD_DECOUPLED_MAX_STATUS_REQUESTS = new Query("Params_*.TAN2StepPar7.ParTAN2Step*.TAN2StepParams_*.decoupled_max_status_requests",false);
+        public final static Query BPD_DECOUPLED_TIME_BEFORE_FIRST_STATUS_REQUEST = new Query("Params_*.TAN2StepPar*.ParTAN2Step*.TAN2StepParams_*.decoupled_time_before_first_status_request",false);
+        public final static Query BPD_DECOUPLED_TIME_BEFORE_NEXT_STATUS_REQUEST = new Query("Params_*.TAN2StepPar*.ParTAN2Step*.TAN2StepParams_*.decoupled_time_before_next_status_request",false);
+        public final static Query BPD_DECOUPLED_MAX_STATUS_REQUESTS = new Query("Params_*.TAN2StepPar*.ParTAN2Step*.TAN2StepParams_*.decoupled_max_status_requests",false);
 
         private String query = null;
         private boolean paramsSet = false;

--- a/src/main/java/org/kapott/hbci/tools/ParameterFinder.java
+++ b/src/main/java/org/kapott/hbci/tools/ParameterFinder.java
@@ -48,6 +48,16 @@ public class ParameterFinder
          */
         public final static Query BPD_PINTAN_ORDERHASHMODE = new Query("Params_*.TAN2StepPar{0}.ParTAN2Step*.orderhashmode",true);
 
+        /**
+         * Die 3 verschiedenen Parameter für status refresh requests beim Decoupled Verfahren:
+         *  1. Minimale Zeit vor dem ersten refresh (Sekunden).
+         *  2. Minimale Zeit vor weiteren refreshes (Sekunden).
+         *  3. Maximale Anzahl von refreshes.
+         */
+        public final static Query BPD_DECOUPLED_TIME_BEFORE_FIRST_STATUS_REQUEST = new Query("Params_*.TAN2StepPar7.ParTAN2Step*.TAN2StepParams_*.decoupled_time_before_first_status_request",false);
+        public final static Query BPD_DECOUPLED_TIME_BEFORE_NEXT_STATUS_REQUEST = new Query("Params_*.TAN2StepPar7.ParTAN2Step*.TAN2StepParams_*.decoupled_time_before_next_status_request",false);
+        public final static Query BPD_DECOUPLED_MAX_STATUS_REQUESTS = new Query("Params_*.TAN2StepPar7.ParTAN2Step*.TAN2StepParams_*.decoupled_max_status_requests",false);
+
         private String query = null;
         private boolean paramsSet = false;
         


### PR DESCRIPTION
Diese Änderung fügt durch einen neuen Callback `NEED_PT_DECOUPLED_RETRY` die Funktionalität hinzu, zu erkennen, ob der Kunde beim Decoupled Verfahren (e.g. PushTAN 2.0) noch keine Bestätigung gegeben hat. In `retData` wird die Mindestwartezeit der Bank übergeben, damit die Applikation die Möglichkeit hat den Callback belieg lange selbst zu verzögern und Wartehinweise anzuzeigen. Bei nicht ausreichender Wartezeit schläft `hbci4java` den Thread dann die restliche Zeit.

Siehe #91 für bisherige Diskussion.