### PR TITLE
Unendliche Wiederholungen bei einem abgelehnten Decoupled-Verfahren verhindern

### DIFF
--- a/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
+++ b/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
@@ -183,6 +183,14 @@ public class GVTAN2Step extends HBCIJobImpl
     @Override
     public HBCIJobImpl redo()
     {
+        // Falls der redo job 'this' ist, wird ein redo für das Decoupled Verfahren durchgeführt, welcher jeweils
+        // nur ein mal pro 3956 status wiederholt werden soll. Um unendliche Wiederholungen zu vermeiden setzen wir
+        // also redo=null.
+        if (this.redo == this) {
+            HBCIJobImpl redo = this.redo;
+            this.redo = null;
+            return redo;
+        }
         return this.redo;
     }
     


### PR DESCRIPTION
Mit der Änderung in https://github.com/hbci4j/hbci4java/pull/94 habe ich den Fehler übersehen, dass das Ablehnen eines Bank Prozesses im Decoupled Verfahren dafür sorgt, dass [`GVTAN2Step::extractResults()`](https://github.com/hbci4j/hbci4java/blob/ec36007e47035828dc079ed17c44f9435ab47cac/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java#L203) nicht erneut aufgerufen wird, und somit niemals `this.redo = null` gesetzt wird.

Das sorgt für ein Back-And-Forth in welcher die Bank immer wieder `9210` schickt (Auftrag auf Kundenwunsch abgebrochen), und wir mit einem Redo von dem Decoupled Status Refresh antworten, da keine der Antowortsegmente aus der `9210` Response für den `GVTAN2Step` task gedacht sind, und `this.redo = null` übersprungen wird.

Da die `GVTAN2Step::redo()` Methode ja auch für Redos für `3040` Responses zuständig ist, war ich mir nicht sicher was die beste Lösung für dieses Problem ist. Mit dem Ansatz in dieser PR setze ich `redo` einfach in dem `redo()` getter auf `null`, wenn `redo == this` ist. Mit diesem Check wissen wir, dass es ein Redo für das Decoupled Verfahren ist, und dieser nur ein mal pro `3956` status wiederholt werden soll.

Wenn jetzt also in `HBCIDialog` [`task.redo()`](https://github.com/hbci4j/hbci4java/blob/ec36007e47035828dc079ed17c44f9435ab47cac/src/main/java/org/kapott/hbci/manager/HBCIDialog.java#L346C45-L346C49) aufgerufen wird, ist `redo` in `GVTAN2Step` wieder `null`, also wird der Decoupled Status Refresh beim nächsten mal nicht wiederholt, und der Bank Prozess wie erwartet mit dem Fehler `Auftrag auf Kundenwunsch abgebrochen` beendet.

Es gibt vermutlich 5+ andere Wege diese endlose Wiederholung zu umgehen, also bin ich für alle Änderungsvorschläge offen.