### PR TITLE
Decoupled status refresh bei Dialoginitialisierung

### DIFF
--- a/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
+++ b/src/main/java/org/kapott/hbci/GV/GVTAN2Step.java
@@ -54,9 +54,6 @@ public class GVTAN2Step extends HBCIJobImpl
     
     private HBCIJobImpl redo;
 
-    // Die bisherige Anzahl von Decoupled Status refresh requests.
-    private int decoupledRefreshes = 0;
-    
     public static String getLowlevelName()
     {
         return "TAN2Step";
@@ -229,38 +226,8 @@ public class GVTAN2Step extends HBCIJobImpl
                     HBCIUtils.log("found status code 3040, need to repeat task " + this.task.getHBCICode(),HBCIUtils.LOG_DEBUG);
                     HBCIUtils.log("Weitere Daten folgen",HBCIUtils.LOG_INFO);
                     this.redo = this.task;
-                } else if (Feature.PINTAN_DECOUPLED_REFRESH.isEnabled() && KnownReturncode.W3956.searchReturnValue(msgstatus.segStatus.getWarnings()) != null) {
-                    // Beim Decoupled Verfahren kann die Bank ein 3956 senden, wenn der Nutzer den Prozess noch nicht bestätigt hat.
-                    // In diesem Fall muss dieser task wiederholt werden, um erneut zu prüfen, ob die Bestätigung erfolgt ist.
-                    // Wir benachrichtigen die Applikation mit einem entsprechenden Callback und warten eine mögliche Mindestzeit.
-                    HBCIUtils.log("found status code 3956, need to repeat task " + this.getHBCICode(),HBCIUtils.LOG_DEBUG);
-                    AbstractPinTanPassport pinTanPassport = (AbstractPinTanPassport) getMainPassport();
-                    if (pinTanPassport.getDecoupledMaxRefreshes() != null && this.decoupledRefreshes >= pinTanPassport.getDecoupledMaxRefreshes()) {
-                        throw new HBCI_Exception("*** the maximum number of decoupled refreshes has been reached.");
-                    }
-                    Integer timeBeforeDecoupledRefresh = this.decoupledRefreshes == 0
-                            ? pinTanPassport.getMinimumTimeBeforeFirstDecoupledRefresh()
-                            : pinTanPassport.getMinimumTimeBeforeNextDecoupledRefresh();
-                    long callbackDurationMs = System.currentTimeMillis();
-                    HBCIUtilsInternal.getCallback().callback(
-                            getMainPassport(),
-                            HBCICallback.NEED_PT_DECOUPLED_RETRY,
-                            "*** decoupled SCA still required",
-                            HBCICallback.TYPE_TEXT,
-                            new StringBuffer(String.valueOf(timeBeforeDecoupledRefresh != null ? timeBeforeDecoupledRefresh : 0)));
-                    callbackDurationMs = System.currentTimeMillis() - callbackDurationMs;
-                    if (timeBeforeDecoupledRefresh != null && callbackDurationMs < timeBeforeDecoupledRefresh * 1000) {
-                        long sleepMs = timeBeforeDecoupledRefresh * 1000 - callbackDurationMs;
-                        HBCIUtils.log(String.format(
-                                "The pause before the next decoupled request was too short. Sleeping for %dms to reach the required delay.", sleepMs
-                        ),HBCIUtils.LOG_INFO);
-                        try {
-                            Thread.sleep(sleepMs);
-                        } catch (InterruptedException e) {
-                            throw new HBCI_Exception("*** Decoupled refresh sleep was interrupted.");
-                        }
-                    }
-                    this.decoupledRefreshes++;
+                } else if (((AbstractPinTanPassport) getMainPassport()).shouldPerformDecoupledRefresh(msgstatus.segStatus)) {
+                    HBCIUtils.log("Decoupled refresh required for task " + this.getHBCICode() + ". Redoing task",HBCIUtils.LOG_DEBUG);
                     this.redo = this;
                 } else {
                     this.redo = null;

--- a/src/main/java/org/kapott/hbci/dialog/AbstractRawHBCIDialog.java
+++ b/src/main/java/org/kapott/hbci/dialog/AbstractRawHBCIDialog.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import org.kapott.hbci.dialog.KnownTANProcess.Variant;
 import org.kapott.hbci.exceptions.HBCI_Exception;
+import org.kapott.hbci.manager.Feature;
 import org.kapott.hbci.manager.HBCIKernelImpl;
 import org.kapott.hbci.manager.HBCIUtils;
 import org.kapott.hbci.passport.HBCIPassportInternal;
@@ -68,7 +69,7 @@ public abstract class AbstractRawHBCIDialog implements RawHBCIDialog
             ctx.setRepeat(false);
             
             // Checken, ob ein Neustart noch moeglich ist:
-            if (this.executions.get() > 2)
+            if (this.executions.get() > 2 && (!Feature.PINTAN_DECOUPLED_REFRESH.isEnabled() || KnownReturncode.W3956.searchReturnValue(ctx.getMsgStatus().segStatus.getWarnings()) == null))
             {
                 HBCIUtils.log("dialog loop detected for " + this.getTemplate() + ", id " + ctx.getDialogId() + ", message number: " + ctx.getMsgNum() + ", execution count: " + this.executions.get(),HBCIUtils.LOG_ERR);
                 throw new HBCI_Exception("dialog loop detected for " + this.getTemplate());

--- a/src/main/java/org/kapott/hbci/dialog/AbstractRawHBCIDialog.java
+++ b/src/main/java/org/kapott/hbci/dialog/AbstractRawHBCIDialog.java
@@ -69,7 +69,9 @@ public abstract class AbstractRawHBCIDialog implements RawHBCIDialog
             ctx.setRepeat(false);
             
             // Checken, ob ein Neustart noch moeglich ist:
-            if (this.executions.get() > 2 && (!Feature.PINTAN_DECOUPLED_REFRESH.isEnabled() || KnownReturncode.W3956.searchReturnValue(ctx.getMsgStatus().segStatus.getWarnings()) == null))
+            if (this.executions.get() > 2 &&
+                    (!Feature.PINTAN_DECOUPLED_REFRESH.isEnabled() ||
+                            (ctx.getMsgStatus() != null && ctx.getMsgStatus().segStatus != null && KnownReturncode.W3956.searchReturnValue(ctx.getMsgStatus().segStatus.getWarnings()) == null)))
             {
                 HBCIUtils.log("dialog loop detected for " + this.getTemplate() + ", id " + ctx.getDialogId() + ", message number: " + ctx.getMsgNum() + ", execution count: " + this.executions.get(),HBCIUtils.LOG_ERR);
                 throw new HBCI_Exception("dialog loop detected for " + this.getTemplate());

--- a/src/main/java/org/kapott/hbci/passport/HBCIPassportPinTan.java
+++ b/src/main/java/org/kapott/hbci/passport/HBCIPassportPinTan.java
@@ -408,11 +408,15 @@ public class HBCIPassportPinTan extends AbstractPinTanPassport
 
                     setPersistentData("externalid",null); // External-ID aus Passport entfernen
 
-                    // Beim Decoupled-Verfahren erhalten wir keine TAN. Daher müssen wir hier auch nichts signieren.
-                    // Wir ignorieren die Antwort aus dem Callback komplett
-                    if (callback == HBCICallback.NEED_PT_DECOUPLED)
-                      return (getPIN()+"|").getBytes("ISO-8859-1");
-                    
+                    if (callback == HBCICallback.NEED_PT_DECOUPLED) {
+                        // Beim start des Decoupled-Verfahrens wird die Anzahl der refreshes auf 0 gesetzt, falls durch
+                        // einen vorherigen decoupled prozess bereits refreshes durchgeführt wurden.
+                        this.decoupledRefreshes = 0;
+                        // Beim Decoupled-Verfahren erhalten wir keine TAN. Daher müssen wir hier auch nichts signieren.
+                        // Wir ignorieren die Antwort aus dem Callback komplett
+                        return (getPIN()+"|").getBytes("ISO-8859-1");
+                    }
+
                     if (payload == null || payload.length()==0)
                         throw new HBCI_Exception(HBCIUtilsInternal.getLocMsg("EXCMSG_TANZERO"));
                     


### PR DESCRIPTION
Wie im Forum besprochen ist hier eine PR für decoupled refreshes bei der Dialoginitialisierung.

Bei der dialog loop detection war ich mir nicht ganz sicher was die korrekte Lösung ist. Hab jetzt einfach auch dort einen check nach `3956` in dem status hinzugefügt, um loops in einer decoupled Situation zu erlauben.