### PR TITLE
Ursprungsbetrag bei Rückbuchungen

### DIFF
--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200102.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200102.java
@@ -226,8 +226,13 @@ public class ParseCamt05200102 extends AbstractCamtParser
         
         // Ist es eine Rueckbuchung?
         boolean rueckbuchung = tx.getRtrInf() != null && tx.getRtrInf().getRsn() != null && tx.getRtrInf().getRsn().getCd() != null && tx.getRtrInf().getRsn().getCd().length() > 0;
-        if (rueckbuchung) // Bei Rueckbuchung tauschen wir Creditor und Debitor
-          haben = !haben;
+        if (rueckbuchung) { // Bei Rueckbuchung tauschen wir Creditor und Debitor
+            haben = !haben;
+            if (tx.getAmtDtls() != null && tx.getAmtDtls().getInstdAmt() != null && tx.getAmtDtls().getInstdAmt().getAmt() != null) {
+                // Ursprungsbetrag bei Rückbuchungen
+                line.orig_value = new Value(tx.getAmtDtls().getInstdAmt().getAmt().getValue(), tx.getAmtDtls().getInstdAmt().getAmt().getCcy());
+            }
+        }
         
         ////////////////////////////////////////////////////////////////////////
         // Buchungs-ID

--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200103.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200103.java
@@ -227,8 +227,13 @@ public class ParseCamt05200103 extends AbstractCamtParser
 
         // Ist es eine Rueckbuchung?
         boolean rueckbuchung = tx.getRtrInf() != null && tx.getRtrInf().getRsn() != null && tx.getRtrInf().getRsn().getCd() != null && tx.getRtrInf().getRsn().getCd().length() > 0;
-        if (rueckbuchung) // Bei Rueckbuchung tauschen wir Creditor und Debitor
-          haben = !haben;
+        if (rueckbuchung) { // Bei Rueckbuchung tauschen wir Creditor und Debitor
+            haben = !haben;
+            if (tx.getAmtDtls() != null && tx.getAmtDtls().getInstdAmt() != null && tx.getAmtDtls().getInstdAmt().getAmt() != null) {
+                // Ursprungsbetrag bei Rückbuchungen
+                line.orig_value = new Value(tx.getAmtDtls().getInstdAmt().getAmt().getValue(), tx.getAmtDtls().getInstdAmt().getAmt().getCcy());
+            }
+        }
 
         ////////////////////////////////////////////////////////////////////////
         // Buchungs-ID

--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200104.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200104.java
@@ -227,8 +227,13 @@ public class ParseCamt05200104 extends AbstractCamtParser
 
         // Ist es eine Rueckbuchung?
         boolean rueckbuchung = tx.getRtrInf() != null && tx.getRtrInf().getRsn() != null && tx.getRtrInf().getRsn().getCd() != null && tx.getRtrInf().getRsn().getCd().length() > 0;
-        if (rueckbuchung) // Bei Rueckbuchung tauschen wir Creditor und Debitor
-          haben = !haben;
+        if (rueckbuchung) { // Bei Rueckbuchung tauschen wir Creditor und Debitor
+            haben = !haben;
+            if (tx.getAmtDtls() != null && tx.getAmtDtls().getInstdAmt() != null && tx.getAmtDtls().getInstdAmt().getAmt() != null) {
+                // Ursprungsbetrag bei Rückbuchungen
+                line.orig_value = new Value(tx.getAmtDtls().getInstdAmt().getAmt().getValue(), tx.getAmtDtls().getInstdAmt().getAmt().getCcy());
+            }
+        }
 
         ////////////////////////////////////////////////////////////////////////
         // Buchungs-ID

--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200105.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200105.java
@@ -227,8 +227,13 @@ public class ParseCamt05200105 extends AbstractCamtParser
 
         // Ist es eine Rueckbuchung?
         boolean rueckbuchung = tx.getRtrInf() != null && tx.getRtrInf().getRsn() != null && tx.getRtrInf().getRsn().getCd() != null && tx.getRtrInf().getRsn().getCd().length() > 0;
-        if (rueckbuchung) // Bei Rueckbuchung tauschen wir Creditor und Debitor
-          haben = !haben;
+        if (rueckbuchung) { // Bei Rueckbuchung tauschen wir Creditor und Debitor
+            haben = !haben;
+            if (tx.getAmtDtls() != null && tx.getAmtDtls().getInstdAmt() != null && tx.getAmtDtls().getInstdAmt().getAmt() != null) {
+                // Ursprungsbetrag bei Rückbuchungen
+                line.orig_value = new Value(tx.getAmtDtls().getInstdAmt().getAmt().getValue(), tx.getAmtDtls().getInstdAmt().getAmt().getCcy());
+            }
+        }
         
         ////////////////////////////////////////////////////////////////////////
         // Buchungs-ID

--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200106.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200106.java
@@ -227,8 +227,13 @@ public class ParseCamt05200106 extends AbstractCamtParser
         
         // Ist es eine Rueckbuchung?
         boolean rueckbuchung = tx.getRtrInf() != null && tx.getRtrInf().getRsn() != null && tx.getRtrInf().getRsn().getCd() != null && tx.getRtrInf().getRsn().getCd().length() > 0;
-        if (rueckbuchung) // Bei Rueckbuchung tauschen wir Creditor und Debitor
-          haben = !haben;
+        if (rueckbuchung) { // Bei Rueckbuchung tauschen wir Creditor und Debitor
+            haben = !haben;
+            if (tx.getAmtDtls() != null && tx.getAmtDtls().getInstdAmt() != null && tx.getAmtDtls().getInstdAmt().getAmt() != null) {
+                // Ursprungsbetrag bei Rückbuchungen
+                line.orig_value = new Value(tx.getAmtDtls().getInstdAmt().getAmt().getValue(), tx.getAmtDtls().getInstdAmt().getAmt().getCcy());
+            }
+        }
 
         ////////////////////////////////////////////////////////////////////////
         // Buchungs-ID

--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200107.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200107.java
@@ -227,8 +227,13 @@ public class ParseCamt05200107 extends AbstractCamtParser
 
         // Ist es eine Rueckbuchung?
         boolean rueckbuchung = tx.getRtrInf() != null && tx.getRtrInf().getRsn() != null && tx.getRtrInf().getRsn().getCd() != null && tx.getRtrInf().getRsn().getCd().length() > 0;
-        if (rueckbuchung) // Bei Rueckbuchung tauschen wir Creditor und Debitor
-          haben = !haben;
+        if (rueckbuchung) { // Bei Rueckbuchung tauschen wir Creditor und Debitor
+            haben = !haben;
+            if (tx.getAmtDtls() != null && tx.getAmtDtls().getInstdAmt() != null && tx.getAmtDtls().getInstdAmt().getAmt() != null) {
+                // Ursprungsbetrag bei Rückbuchungen
+                line.orig_value = new Value(tx.getAmtDtls().getInstdAmt().getAmt().getValue(), tx.getAmtDtls().getInstdAmt().getAmt().getCcy());
+            }
+        }
         
         ////////////////////////////////////////////////////////////////////////
         // Buchungs-ID

--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200108.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200108.java
@@ -228,8 +228,13 @@ public class ParseCamt05200108 extends AbstractCamtParser
 
         // Ist es eine Rueckbuchung?
         boolean rueckbuchung = tx.getRtrInf() != null && tx.getRtrInf().getRsn() != null && tx.getRtrInf().getRsn().getCd() != null && tx.getRtrInf().getRsn().getCd().length() > 0;
-        if (rueckbuchung) // Bei Rueckbuchung tauschen wir Creditor und Debitor
-          haben = !haben;
+        if (rueckbuchung) { // Bei Rueckbuchung tauschen wir Creditor und Debitor
+            haben = !haben;
+            if (tx.getAmtDtls() != null && tx.getAmtDtls().getInstdAmt() != null && tx.getAmtDtls().getInstdAmt().getAmt() != null) {
+                // Ursprungsbetrag bei Rückbuchungen
+                line.orig_value = new Value(tx.getAmtDtls().getInstdAmt().getAmt().getValue(), tx.getAmtDtls().getInstdAmt().getAmt().getCcy());
+            }
+        }
         
         ////////////////////////////////////////////////////////////////////////
         // Buchungs-ID

--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200109.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200109.java
@@ -227,8 +227,13 @@ public class ParseCamt05200109 extends AbstractCamtParser
 
         // Ist es eine Rueckbuchung?
         boolean rueckbuchung = tx.getRtrInf() != null && tx.getRtrInf().getRsn() != null && tx.getRtrInf().getRsn().getCd() != null && tx.getRtrInf().getRsn().getCd().length() > 0;
-        if (rueckbuchung) // Bei Rueckbuchung tauschen wir Creditor und Debitor
-          haben = !haben;
+        if (rueckbuchung) { // Bei Rueckbuchung tauschen wir Creditor und Debitor
+            haben = !haben;
+            if (tx.getAmtDtls() != null && tx.getAmtDtls().getInstdAmt() != null && tx.getAmtDtls().getInstdAmt().getAmt() != null) {
+                // Ursprungsbetrag bei Rückbuchungen
+                line.orig_value = new Value(tx.getAmtDtls().getInstdAmt().getAmt().getValue(), tx.getAmtDtls().getInstdAmt().getAmt().getCcy());
+            }
+        }
         
         ////////////////////////////////////////////////////////////////////////
         // Buchungs-ID


### PR DESCRIPTION
Hi,

bei Rücklastschriften steht in **/Document/BkToCstmrAcctRpt/Rpt/Ntry/NtryDtls/TxDtls/AmtDtls/InstdAmt/Amt** der Ursprungsbetrag der Lastschrift.

Ich bin mir nicht sicher, ob ich Fälle übersehe und stelle den PR erstmal als Diskussionsgrundlage ein.