### PR TITLE
Grund für Rückbuchung, Test angepasst

### DIFF
--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200102.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200102.java
@@ -232,6 +232,11 @@ public class ParseCamt05200102 extends AbstractCamtParser
                 // Ursprungsbetrag bei Rückbuchungen
                 line.orig_value = new Value(tx.getAmtDtls().getInstdAmt().getAmt().getValue(), tx.getAmtDtls().getInstdAmt().getAmt().getCcy());
             }
+
+            if (tx.getRtrInf().getAddtlInf() != null) {
+                // Grund für Rückbuchung
+                line.additional = String.join(",", trim(tx.getRtrInf().getAddtlInf()));
+            }
         }
         
         ////////////////////////////////////////////////////////////////////////

--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200103.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200103.java
@@ -233,6 +233,11 @@ public class ParseCamt05200103 extends AbstractCamtParser
                 // Ursprungsbetrag bei Rückbuchungen
                 line.orig_value = new Value(tx.getAmtDtls().getInstdAmt().getAmt().getValue(), tx.getAmtDtls().getInstdAmt().getAmt().getCcy());
             }
+
+            if (tx.getRtrInf().getAddtlInf() != null) {
+                // Grund für Rückbuchung
+                line.additional = String.join(",", trim(tx.getRtrInf().getAddtlInf()));
+            }
         }
 
         ////////////////////////////////////////////////////////////////////////

--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200104.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200104.java
@@ -233,6 +233,11 @@ public class ParseCamt05200104 extends AbstractCamtParser
                 // Ursprungsbetrag bei Rückbuchungen
                 line.orig_value = new Value(tx.getAmtDtls().getInstdAmt().getAmt().getValue(), tx.getAmtDtls().getInstdAmt().getAmt().getCcy());
             }
+
+            if (tx.getRtrInf().getAddtlInf() != null) {
+                // Grund für Rückbuchung
+                line.additional = String.join(",", trim(tx.getRtrInf().getAddtlInf()));
+            }
         }
 
         ////////////////////////////////////////////////////////////////////////

--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200105.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200105.java
@@ -233,6 +233,11 @@ public class ParseCamt05200105 extends AbstractCamtParser
                 // Ursprungsbetrag bei Rückbuchungen
                 line.orig_value = new Value(tx.getAmtDtls().getInstdAmt().getAmt().getValue(), tx.getAmtDtls().getInstdAmt().getAmt().getCcy());
             }
+
+            if (tx.getRtrInf().getAddtlInf() != null) {
+                // Grund für Rückbuchung
+                line.additional = String.join(",", trim(tx.getRtrInf().getAddtlInf()));
+            }
         }
         
         ////////////////////////////////////////////////////////////////////////

--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200106.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200106.java
@@ -233,6 +233,11 @@ public class ParseCamt05200106 extends AbstractCamtParser
                 // Ursprungsbetrag bei Rückbuchungen
                 line.orig_value = new Value(tx.getAmtDtls().getInstdAmt().getAmt().getValue(), tx.getAmtDtls().getInstdAmt().getAmt().getCcy());
             }
+
+            if (tx.getRtrInf().getAddtlInf() != null) {
+                // Grund für Rückbuchung
+                line.additional = String.join(",", trim(tx.getRtrInf().getAddtlInf()));
+            }
         }
 
         ////////////////////////////////////////////////////////////////////////

--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200107.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200107.java
@@ -233,6 +233,11 @@ public class ParseCamt05200107 extends AbstractCamtParser
                 // Ursprungsbetrag bei Rückbuchungen
                 line.orig_value = new Value(tx.getAmtDtls().getInstdAmt().getAmt().getValue(), tx.getAmtDtls().getInstdAmt().getAmt().getCcy());
             }
+
+            if (tx.getRtrInf().getAddtlInf() != null) {
+                // Grund für Rückbuchung
+                line.additional = String.join(",", trim(tx.getRtrInf().getAddtlInf()));
+            }
         }
         
         ////////////////////////////////////////////////////////////////////////

--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200108.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200108.java
@@ -234,6 +234,11 @@ public class ParseCamt05200108 extends AbstractCamtParser
                 // Ursprungsbetrag bei Rückbuchungen
                 line.orig_value = new Value(tx.getAmtDtls().getInstdAmt().getAmt().getValue(), tx.getAmtDtls().getInstdAmt().getAmt().getCcy());
             }
+
+            if (tx.getRtrInf().getAddtlInf() != null) {
+                // Grund für Rückbuchung
+                line.additional = String.join(",", trim(tx.getRtrInf().getAddtlInf()));
+            }
         }
         
         ////////////////////////////////////////////////////////////////////////

--- a/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200109.java
+++ b/src/main/java/org/kapott/hbci/GV/parsers/ParseCamt05200109.java
@@ -233,6 +233,11 @@ public class ParseCamt05200109 extends AbstractCamtParser
                 // Ursprungsbetrag bei Rückbuchungen
                 line.orig_value = new Value(tx.getAmtDtls().getInstdAmt().getAmt().getValue(), tx.getAmtDtls().getInstdAmt().getAmt().getCcy());
             }
+
+            if (tx.getRtrInf().getAddtlInf() != null) {
+                // Grund für Rückbuchung
+                line.additional = String.join(",", trim(tx.getRtrInf().getAddtlInf()));
+            }
         }
         
         ////////////////////////////////////////////////////////////////////////

--- a/src/test/java/org/kapott/hbci4java/sepa/TestCamtParse.java
+++ b/src/test/java/org/kapott/hbci4java/sepa/TestCamtParse.java
@@ -275,6 +275,9 @@ public class TestCamtParse extends AbstractTest
                 Assert.assertEquals("Gegenkonto IBAN falsch","DES1234567890",l.other.iban);
                 Assert.assertEquals("Gegenkonto BIC falsch","TESTS1234",l.other.bic);
                 Assert.assertEquals("Gegenkonto Name falsch","Sven Schuldner",l.other.name);
+                Assert.assertNotNull("orig_value ist null", l.orig_value);
+                Assert.assertEquals("orig_value ist falsch", 0, new BigDecimal("50").compareTo(l.orig_value.getBigDecimalValue()));
+                Assert.assertEquals("Grund für Rückbuchung falsch", "RUECKLASTSCHRIFT Sonstige Gruende", l.additional);
             }
         }
         finally

--- a/src/test/resources/org/kapott/hbci4java/sepa/test-camt-ruecklastschrift.xml
+++ b/src/test/resources/org/kapott/hbci4java/sepa/test-camt-ruecklastschrift.xml
@@ -158,7 +158,7 @@
 							<Rsn>
 								<Cd>MS03</Cd>
 							</Rsn>
-							<AddtlInf>RUECKLASTSCHRIFT Sonstige Gruende</AddtlInf>
+							<AddtlInf>RUECKLASTSCHRIFT Sonstige Gruende </AddtlInf>
 						</RtrInf>
 					</TxDtls>
 				</NtryDtls>


### PR DESCRIPTION
Im Feld **/Document/BkToCstmrAcctRpt/Rpt/Ntry/NtryDtls/TxDtls/RtrInf/AddtlInf** steht bei Lastschriftrückbuchungen der Grund der Rückbuchung.

Der Change schreibt diesen Wert in **UmsLine#additional**

Hinweis: das Leerzeichen in der test XML Datei dient dazu, das trim() sicherzustellen.