### PR TITLE
VOP mit polling

### DIFF
--- a/src/main/java/org/kapott/hbci/GV/GVVoP.java
+++ b/src/main/java/org/kapott/hbci/GV/GVVoP.java
@@ -226,6 +226,7 @@ public class GVVoP extends HBCIJobImpl<GVRVoP>
     @Override
     protected boolean redoAllowed()
     {
+      
       return true;
     }
 }

--- a/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
+++ b/src/main/java/org/kapott/hbci/manager/HBCIDialog.java
@@ -351,7 +351,8 @@ public final class HBCIDialog
                         // Nachricht bei Bedarf erstellen und an die Queue haengen
                         if (newMsg == null)
                         {
-                            newMsg =queue.insertBefore(queue.getMessages().get(0));
+                            newMsg = new HBCIMessage();
+                            queue.append(newMsg);
                         }
                         
                         // Task hinzufuegen

--- a/src/main/java/org/kapott/hbci/passport/AbstractPinTanPassport.java
+++ b/src/main/java/org/kapott/hbci/passport/AbstractPinTanPassport.java
@@ -1577,6 +1577,10 @@ public abstract class AbstractPinTanPassport extends AbstractHBCIPassport
                 if (task.haveTan())
                     continue;
                 
+                //HKVPP brauchen keine TAN, nur HKVPA
+                if(task.haveVoP())
+                  continue; 
+                
                 final String segcode = task.getHBCICode();
                 if (segcode == null)
                 {


### PR DESCRIPTION
Die GLS Bank (artruvia) sendet immer ein 3040 und `3945::Freigabe ohne VOP-Bestätigung nicht möglich`, es muss also immer ein polling erfolgen.
Mit diesere Änderung funktioniert es. Allerdings wir der auftrag noch direkt nach dem anderen ausgeführt, und nicht nach der angegebenen Wartezeit (bei mir 2), ob das Probleme machen kann, weiß ich nith.