### PR TITLE
Update answers.properties für VoP HBCIBatch Callback

### DIFF
--- a/demo/HBCIBatch/answers.properties
+++ b/demo/HBCIBatch/answers.properties
@@ -43,6 +43,11 @@ passphrase=secret
 # Callback-Reason: NEED_PT_PIN
 pin=12345
 
+# VOP Result für das Verification of Payee Verfahren
+# Callback-Reason: HAVE_VOP_RESULT
+# Falls die verification of payee fehlschlägt, wird die Ausführung abgebrochen
+# Alternativ kann der Auftrag mit vopresult=true trotzdem angewiesen werden.
+vopresult=false
 
 # TANs für das PIN/TAN-Verfahren; wird nur benötigt,
 # falls tatsächlich HBCI-PIN/TAN gemacht wird und


### PR DESCRIPTION
Hallo,

vielen Dank für den Merge.

Anbei noch die Änderungen für die answers.properites.
Ich habe es per default auf "false" gestellt, da ein generelles Umgehen der VoP sicher nicht ratsam ist.
Wer HBCIBatch nutzen möchte, sollte sich auch einlesen, oder wie sehen Sie das?

Viele Grüße