### PR TITLE
VOP ExternalId der Callback mitgeben

### DIFF
--- a/src/main/java/org/kapott/hbci/GV/GVVoP.java
+++ b/src/main/java/org/kapott/hbci/GV/GVVoP.java
@@ -196,6 +196,8 @@ public class GVVoP extends HBCIJobImpl<GVRVoP>
         {
           // VOP-Result im Passport speichern und User fragen, ob der Vorgang fortgesetzt werden kann
           p.setPersistentData(AbstractHBCIPassport.KEY_VOP_RESULT,result);
+          p.setPersistentData(AbstractHBCIPassport.KEY_VOP_TASK_ID,task.getExternalId());
+          
           final StringBuffer sb = new StringBuffer();
           HBCIUtilsInternal.getCallback().callback(p,HBCICallback.HAVE_VOP_RESULT,result.getText(),HBCICallback.TYPE_BOOLEAN,sb);
           if (!StringUtil.toBoolean(sb.toString()))
@@ -204,6 +206,7 @@ public class GVVoP extends HBCIJobImpl<GVRVoP>
         finally
         {
           p.setPersistentData(AbstractHBCIPassport.KEY_VOP_RESULT,null);
+          p.setPersistentData(AbstractHBCIPassport.KEY_VOP_TASK_ID,null);
         }
       }
       

--- a/src/main/java/org/kapott/hbci/passport/AbstractHBCIPassport.java
+++ b/src/main/java/org/kapott/hbci/passport/AbstractHBCIPassport.java
@@ -70,6 +70,11 @@ public abstract class AbstractHBCIPassport implements HBCIPassportInternal,Seria
    * Ein Objekt vom Typ {@link VoPResult}.
    */
   public final static String KEY_VOP_RESULT = "__pintan_vop_result___";
+  
+  /**
+   * Die externalID des ursprünglichen Auftrags.
+   */
+  public final static String KEY_VOP_TASK_ID = "__pintan_vop_task_id___";
 
     private String     paramHeader;
 


### PR DESCRIPTION
Dadurch kann der Name im ursprünglichen Auftrag angepasst werden.