### PR TITLE
set msg.append(auth) before msg.append(task) for VoP

### DIFF
--- a/src/main/java/org/kapott/hbci/GV/GVVoP.java
+++ b/src/main/java/org/kapott/hbci/GV/GVVoP.java
@@ -227,8 +227,8 @@ public class GVVoP extends HBCIJobImpl<GVRVoP>
       // Rückmeldungscode 3091 angezeigt. In diesem Fall ist lediglich die Challenge im HITAN durch einen HKTAN zu beantworten.
       // Das heisst: Wir dürfen den eigentlichen Auftrag nochmal mit schicken und müssten nicht den Aufwand betreiben, ihn
       // nur in diesem einen Fall wegzulassen.
-      msg.append(task);
       msg.append(auth);
+      msg.append(task);
     }
     
     /**


### PR DESCRIPTION
Changing the order of auth and task in msg seemed to resolve the issue, in which VoP close match or no match could not be processed for HVB.

HVB seemingly has a strict implementation of this, and expects this order of messages. Other banks seem unaffected by this change.

-----------------

Die Reihenfolge der msgs ist hier entscheidend, denn nur so kann ein close match oder no match von der HVB nicht abstürzen. Habe es mit der SSKM auch ausprobiert, scheint nach wie vor gut zu funktionieren.