### PR TITLE
Korrektur des Banknamens zu BLZ 60491430

### DIFF
--- a/src/main/resources/blz.properties
+++ b/src/main/resources/blz.properties
@@ -4042,7 +4042,7 @@
 50580005=Commerzbank vormals Dresdner Bank|Offenbach am Main|DRESDEFF505|76|hbci.dresdner-bank.de|https://hbci.dresdner-bank.de|300|300|
 87069077=Vereinigte Raiffeisenbank Burgstädt|Burgstädt, Sachs|GENODEF1BST|06|fints2.atruvia.de|https://fints2.atruvia.de/cgi-bin/hbciservlet|300|300|
 66010200=Deutsche Bausparkasse Badenia|Karlsruhe, Baden|BBSPDE6KXXX|09|||||
-60491430=VR-Bank Stromberg-Neckar|Bönnigheim|GENODES1VBB|10|fints2.atruvia.de|https://fints2.atruvia.de/cgi-bin/hbciservlet|300|300|
+60491430=VR-Bank Ludwigsburg|Ludwigsburg|GENODES1VBB|10|fints2.atruvia.de|https://fints2.atruvia.de/cgi-bin/hbciservlet|300|300|
 76080086=Commerzbank vormals Dresdner Bank, PCC DCC-ITGK 2|Nürnberg, Mittelfr|DRESDEFFJ27|09|||||
 60069346=Raiffeisenbank Ehingen-Hochsträß|Ehingen (Donau)|GENODES1REH|10|fints2.atruvia.de|https://fints2.atruvia.de/cgi-bin/hbciservlet|300|300|
 20730012=UniCredit Bank - HVB Settlement EAC12|Hamburg|HYVEDEMME12|09|||||
@@ -4060,3 +4060,4 @@
 50020000=Sberbank Direct|Frankfurt|SEZDDEF1XXX||fints1.atruvia.de|https://fints1.atruvia.de/cgi-bin/hbciservlet|300|300|
 50230888=Ikano Bank AB (publ)||PLFGDE5AIKB|09|fints2.atruvia.de|https://fints2.atruvia.de/cgi-bin/hbciservlet|300|300|
 50030010=PSA Bank Deutschland GmbH|Neu-Isenburg|BPNDDE52XXX|09||https://fints1.atruvia.de/cgi-bin/hbciservlet|300|300|
+


### PR DESCRIPTION
Seit 2021 gehört die BLZ 60491430 zur VR-Bank Ludwigsburg, siehe https://de.wikipedia.org/wiki/VR-Bank_Ludwigsburg.