### PR TITLE
DKKKU/DIKKU-Kreditkartenumsätze unterstützen

### DIFF
--- a/src/main/java/org/kapott/hbci/GV/GVKreditkartenUmsatz.java
+++ b/src/main/java/org/kapott/hbci/GV/GVKreditkartenUmsatz.java
@@ -1,0 +1,101 @@
+/**********************************************************************
+ *
+ * This file is part of HBCI4Java.
+ * Copyright (c) 2026 Franz Bettag
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ **********************************************************************/
+
+package org.kapott.hbci.GV;
+
+import java.util.Properties;
+
+import org.kapott.hbci.GV_Result.GVRKreditkartenUmsatz;
+import org.kapott.hbci.exceptions.HBCI_Exception;
+import org.kapott.hbci.manager.HBCIHandler;
+import org.kapott.hbci.manager.HBCIUtilsInternal;
+import org.kapott.hbci.manager.LogFilter;
+import org.kapott.hbci.status.HBCIMsgStatus;
+
+/**
+ * Implementierung des von einigen Kreditinstituten angebotenen
+ * Geschaeftsvorfalls zum Abruf von Kreditkartenumsaetzen (DKKKU/DIKKU).
+ */
+public class GVKreditkartenUmsatz extends HBCIJobImpl<GVRKreditkartenUmsatz>
+{
+    /**
+     * @return der Lowlevelname.
+     */
+    public static String getLowlevelName()
+    {
+        return "KreditkartenUmsatz";
+    }
+
+    /**
+     * ct.
+     * @param handler der HBCI-Handler.
+     */
+    public GVKreditkartenUmsatz(HBCIHandler handler)
+    {
+        super(handler,getLowlevelName(),new GVRKreditkartenUmsatz());
+
+        addConstraint("my.country",      "KTV.KIK.country", "DE", LogFilter.FILTER_NONE);
+        addConstraint("my.blz",          "KTV.KIK.blz",     null, LogFilter.FILTER_MOST);
+        addConstraint("my.number",       "KTV.number",      null, LogFilter.FILTER_IDS);
+        addConstraint("my.subnumber",    "KTV.subnumber",   "",   LogFilter.FILTER_MOST);
+        addConstraint("cardnumber",      "cardnumber",      null, LogFilter.FILTER_IDS);
+        addConstraint("cardsubnumber",   "cardsubnumber",   "",   LogFilter.FILTER_MOST);
+        addConstraint("startdate",       "startdate",       "",   LogFilter.FILTER_NONE);
+        addConstraint("enddate",         "enddate",         "",   LogFilter.FILTER_NONE);
+        addConstraint("maxentries",      "maxentries",      "",   LogFilter.FILTER_NONE);
+        addConstraint("offset",          "offset",          "",   LogFilter.FILTER_MOST);
+    }
+
+    /**
+     * @see org.kapott.hbci.GV.HBCIJobImpl#redoAllowed()
+     */
+    @Override
+    protected boolean redoAllowed()
+    {
+        return true;
+    }
+
+    /**
+     * @see org.kapott.hbci.GV.HBCIJobImpl#extractResults(org.kapott.hbci.status.HBCIMsgStatus, java.lang.String, int)
+     */
+    @Override
+    protected void extractResults(HBCIMsgStatus msgstatus, String header, int idx)
+    {
+        Properties result = msgstatus.getData();
+        GVRKreditkartenUmsatz target = jobResult;
+
+        for (int i=0; ; i++)
+        {
+            String transactionHeader = HBCIUtilsInternal.withCounter(header + ".transactions",i);
+            if (result.getProperty(transactionHeader + ".cardnumber") == null)
+                break;
+
+            try
+            {
+                target.addTransaction(result,transactionHeader);
+            }
+            catch (IllegalArgumentException e)
+            {
+                throw new HBCI_Exception("Kreditkartenumsatz konnte nicht gelesen werden",e);
+            }
+        }
+    }
+}

--- a/src/main/java/org/kapott/hbci/GV/package.html
+++ b/src/main/java/org/kapott/hbci/GV/package.html
@@ -462,6 +462,22 @@ eines Kontos abgeholt werden.</p>
 </table>
 
 <hr size="1" noshade="noshade"/>
+<h3><a name="kreditkartenumsatz">Kreditkartenumsätze anzeigen</a></h3>
+<p>Mit diesem von einigen Kreditinstituten angebotenen Geschäftsvorfall können
+Umsätze eines Kreditkartenkontos abgeholt werden (DKKKU/DIKKU).</p>
+<table cellpadding="3">
+  <tr valign="top"><td><em>Highlevel-Name</em></td><td><code>KreditkartenUmsatz</code></td><td></td></tr>
+  <tr valign="top"><td><em>Highlevel-Parameter</em></td><td></td><td></td></tr>
+    <tr valign="top"><td></td><td><code>my</code></td><td>Konto</td><td>obligatorisch</td><td>Kontoverbindung, der die Kreditkarte zugeordnet ist</td></tr>
+    <tr valign="top"><td></td><td><code>cardnumber</code></td><td>String</td><td>obligatorisch</td><td>Kreditkartennummer</td></tr>
+    <tr valign="top"><td></td><td><code>cardsubnumber</code></td><td>String</td><td>optional</td><td>Unterkontomerkmal der Kreditkarte</td></tr>
+    <tr valign="top"><td></td><td><code>startdate</code></td><td>Date</td><td>optional</td><td>Nur Umsätze ab diesem Datum abholen</td></tr>
+    <tr valign="top"><td></td><td><code>enddate</code></td><td>Date</td><td>optional</td><td>Nur Umsätze bis zu diesem Datum abholen</td></tr>
+    <tr valign="top"><td></td><td><code>maxentries</code></td><td>String</td><td>optional</td><td>Maximale Anzahl der Einträge je Antwort</td></tr>
+  <tr valign="top"><td><em>Rückgabedaten-Klasse</em></td><td><a href="../GV_Result/GVRKreditkartenUmsatz.html"><code>GVRKreditkartenUmsatz</code></a></td><td></td></tr>
+</table>
+
+<hr size="1" noshade="noshade"/>
 <h3><a name="kumsnew">Neue Kontoumsätze anzeigen</a></h3>
 <p>Mit diesem Geschäftsvorfall kann eine Übersicht über die Kontoumsatzdaten
 eines Kontos abgeholt werden. Dabei werden nur die Umsatzdaten zurückgegeben, die

--- a/src/main/java/org/kapott/hbci/GV_Result/GVRKreditkartenUmsatz.java
+++ b/src/main/java/org/kapott/hbci/GV_Result/GVRKreditkartenUmsatz.java
@@ -22,6 +22,8 @@
 package org.kapott.hbci.GV_Result;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
@@ -29,6 +31,7 @@ import java.util.List;
 import java.util.Properties;
 
 import org.kapott.hbci.structures.Value;
+import org.kapott.hbci.tools.StringUtil;
 
 /**
  * Ergebnis des Kreditkarten-Umsatzabrufs DKKKU/DIKKU.
@@ -57,12 +60,12 @@ public class GVRKreditkartenUmsatz extends GVRKUms
         line.orig_value = parseValue(data.getProperty(header + ".originalvalue"),
                                      data.getProperty(header + ".originalcurrency"),
                                      data.getProperty(header + ".originalcreditdebit"),false);
-        line.customerref = normalize(data.getProperty(header + ".reference"));
+        line.customerref = StringUtil.normalize(data.getProperty(header + ".reference"));
         line.text = "Kreditkartenzahlung";
         line.isCamt = true;
 
-        String purpose = joinDescription(data.getProperty(header + ".purpose"),
-                                         data.getProperty(header + ".location"));
+        String purpose = StringUtil.joinDescription(data.getProperty(header + ".purpose"),
+                                                    data.getProperty(header + ".location"));
         line.addUsage(purpose != null ? purpose : "-");
         booked.add(line);
     }
@@ -87,7 +90,7 @@ public class GVRKreditkartenUmsatz extends GVRKUms
 
     private static Date parseDate(String value, String label)
     {
-        String normalized = normalize(value);
+        String normalized = StringUtil.normalize(value);
         if (normalized == null)
             throw new IllegalArgumentException("DKKKU-Umsatz ohne " + label);
 
@@ -98,7 +101,8 @@ public class GVRKreditkartenUmsatz extends GVRKUms
 
         try
         {
-            return java.sql.Date.valueOf(java.time.LocalDate.parse(normalized));
+            LocalDate date = LocalDate.parse(normalized);
+            return Date.from(date.atStartOfDay(ZoneId.systemDefault()).toInstant());
         }
         catch (RuntimeException e)
         {
@@ -108,8 +112,8 @@ public class GVRKreditkartenUmsatz extends GVRKUms
 
     private static Value parseValue(String amount, String currency, String creditDebit, boolean required)
     {
-        String normalizedAmount = normalize(amount);
-        String normalizedCurrency = normalize(currency);
+        String normalizedAmount = StringUtil.normalize(amount);
+        String normalizedCurrency = StringUtil.normalize(currency);
         if (normalizedAmount == null || normalizedCurrency == null)
         {
             if (required)
@@ -119,10 +123,10 @@ public class GVRKreditkartenUmsatz extends GVRKUms
 
         try
         {
-            BigDecimal value = new BigDecimal(normalizeDecimal(normalizedAmount));
-            if ("D".equalsIgnoreCase(normalize(creditDebit)))
+            BigDecimal value = new BigDecimal(StringUtil.normalizeDecimal(normalizedAmount));
+            if ("D".equalsIgnoreCase(StringUtil.normalize(creditDebit)))
                 value = value.abs().negate();
-            else if ("C".equalsIgnoreCase(normalize(creditDebit)))
+            else if ("C".equalsIgnoreCase(StringUtil.normalize(creditDebit)))
                 value = value.abs();
             return new Value(value.toPlainString(),normalizedCurrency);
         }
@@ -132,29 +136,4 @@ public class GVRKreditkartenUmsatz extends GVRKUms
         }
     }
 
-    private static String normalizeDecimal(String value)
-    {
-        if (value.indexOf(',') >= 0)
-            return value.replace(".","").replace(',','.');
-        return value;
-    }
-
-    private static String joinDescription(String purpose, String location)
-    {
-        String normalizedPurpose = normalize(purpose);
-        String normalizedLocation = normalize(location);
-        if (normalizedPurpose == null)
-            return normalizedLocation;
-        if (normalizedLocation == null || normalizedPurpose.equalsIgnoreCase(normalizedLocation))
-            return normalizedPurpose;
-        return normalizedPurpose + " / " + normalizedLocation;
-    }
-
-    private static String normalize(String value)
-    {
-        if (value == null)
-            return null;
-        String normalized = value.trim();
-        return normalized.length() > 0 ? normalized : null;
-    }
 }

--- a/src/main/java/org/kapott/hbci/GV_Result/GVRKreditkartenUmsatz.java
+++ b/src/main/java/org/kapott/hbci/GV_Result/GVRKreditkartenUmsatz.java
@@ -1,0 +1,160 @@
+/**********************************************************************
+ *
+ * This file is part of HBCI4Java.
+ * Copyright (c) 2026 Franz Bettag
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ **********************************************************************/
+
+package org.kapott.hbci.GV_Result;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.List;
+import java.util.Properties;
+
+import org.kapott.hbci.structures.Value;
+
+/**
+ * Ergebnis des Kreditkarten-Umsatzabrufs DKKKU/DIKKU.
+ *
+ * Die Buchungen werden zugleich als normale {@link GVRKUms.UmsLine}
+ * bereitgestellt, damit Anwendungen ihre bestehende Umsatzverarbeitung
+ * wiederverwenden koennen.
+ */
+public class GVRKreditkartenUmsatz extends GVRKUms
+{
+    private final List<UmsLine> booked = new ArrayList<UmsLine>();
+
+    /**
+     * Fuegt einen von HBCI4Java dekodierten DIKKU-Umsatz hinzu.
+     * @param data dekodierte Nachrichtendaten.
+     * @param header Property-Prefix des Umsatzes.
+     */
+    public void addTransaction(Properties data, String header)
+    {
+        UmsLine line = new UmsLine();
+        line.bdate = parseDate(data.getProperty(header + ".bookingdate"),"Buchungsdatum");
+        line.valuta = parseDate(data.getProperty(header + ".valuedate"),"Valutadatum");
+        line.value = parseValue(data.getProperty(header + ".value"),
+                                data.getProperty(header + ".currency"),
+                                data.getProperty(header + ".creditdebit"),true);
+        line.orig_value = parseValue(data.getProperty(header + ".originalvalue"),
+                                     data.getProperty(header + ".originalcurrency"),
+                                     data.getProperty(header + ".originalcreditdebit"),false);
+        line.customerref = normalize(data.getProperty(header + ".reference"));
+        line.text = "Kreditkartenzahlung";
+        line.isCamt = true;
+
+        String purpose = joinDescription(data.getProperty(header + ".purpose"),
+                                         data.getProperty(header + ".location"));
+        line.addUsage(purpose != null ? purpose : "-");
+        booked.add(line);
+    }
+
+    /**
+     * @see org.kapott.hbci.GV_Result.GVRKUms#getFlatData()
+     */
+    @Override
+    public List<UmsLine> getFlatData()
+    {
+        return new ArrayList<UmsLine>(booked);
+    }
+
+    /**
+     * @see org.kapott.hbci.GV_Result.GVRKUms#getFlatDataUnbooked()
+     */
+    @Override
+    public List<UmsLine> getFlatDataUnbooked()
+    {
+        return Collections.emptyList();
+    }
+
+    private static Date parseDate(String value, String label)
+    {
+        String normalized = normalize(value);
+        if (normalized == null)
+            throw new IllegalArgumentException("DKKKU-Umsatz ohne " + label);
+
+        if (normalized.matches("[0-9]{8}"))
+            normalized = normalized.substring(0,4) + "-" +
+                         normalized.substring(4,6) + "-" +
+                         normalized.substring(6,8);
+
+        try
+        {
+            return java.sql.Date.valueOf(java.time.LocalDate.parse(normalized));
+        }
+        catch (RuntimeException e)
+        {
+            throw new IllegalArgumentException("Ungueltiges DKKKU-" + label,e);
+        }
+    }
+
+    private static Value parseValue(String amount, String currency, String creditDebit, boolean required)
+    {
+        String normalizedAmount = normalize(amount);
+        String normalizedCurrency = normalize(currency);
+        if (normalizedAmount == null || normalizedCurrency == null)
+        {
+            if (required)
+                throw new IllegalArgumentException("DKKKU-Umsatz ohne Betrag oder Waehrung");
+            return null;
+        }
+
+        try
+        {
+            BigDecimal value = new BigDecimal(normalizeDecimal(normalizedAmount));
+            if ("D".equalsIgnoreCase(normalize(creditDebit)))
+                value = value.abs().negate();
+            else if ("C".equalsIgnoreCase(normalize(creditDebit)))
+                value = value.abs();
+            return new Value(value.toPlainString(),normalizedCurrency);
+        }
+        catch (NumberFormatException e)
+        {
+            throw new IllegalArgumentException("Ungueltiger DKKKU-Betrag",e);
+        }
+    }
+
+    private static String normalizeDecimal(String value)
+    {
+        if (value.indexOf(',') >= 0)
+            return value.replace(".","").replace(',','.');
+        return value;
+    }
+
+    private static String joinDescription(String purpose, String location)
+    {
+        String normalizedPurpose = normalize(purpose);
+        String normalizedLocation = normalize(location);
+        if (normalizedPurpose == null)
+            return normalizedLocation;
+        if (normalizedLocation == null || normalizedPurpose.equalsIgnoreCase(normalizedLocation))
+            return normalizedPurpose;
+        return normalizedPurpose + " / " + normalizedLocation;
+    }
+
+    private static String normalize(String value)
+    {
+        if (value == null)
+            return null;
+        String normalized = value.trim();
+        return normalized.length() > 0 ? normalized : null;
+    }
+}

--- a/src/main/java/org/kapott/hbci/tools/StringUtil.java
+++ b/src/main/java/org/kapott/hbci/tools/StringUtil.java
@@ -105,6 +105,47 @@ public class StringUtil
       }
       return sb.toString();
     }
-}
 
+    /**
+     * Normalisiert einen Dezimalwert mit deutschem Dezimaltrennzeichen.
+     * @param value der zu normalisierende Wert.
+     * @return der Wert mit Punkt als Dezimaltrennzeichen.
+     */
+    public static String normalizeDecimal(String value)
+    {
+        if (value == null || value.indexOf(',') < 0)
+            return value;
+        return value.replace(".","").replace(',','.');
+    }
+
+    /**
+     * Verbindet Verwendungszweck und Ort zu einer Beschreibung.
+     * @param purpose der Verwendungszweck.
+     * @param location der Ort.
+     * @return die verbundene Beschreibung oder NULL.
+     */
+    public static String joinDescription(String purpose, String location)
+    {
+        String normalizedPurpose = normalize(purpose);
+        String normalizedLocation = normalize(location);
+        if (normalizedPurpose == null)
+            return normalizedLocation;
+        if (normalizedLocation == null || normalizedPurpose.equalsIgnoreCase(normalizedLocation))
+            return normalizedPurpose;
+        return normalizedPurpose + " / " + normalizedLocation;
+    }
+
+    /**
+     * Entfernt Whitespace am Anfang und Ende eines Strings.
+     * @param value der zu normalisierende Wert.
+     * @return der normalisierte Wert oder NULL, wenn kein Text enthalten ist.
+     */
+    public static String normalize(String value)
+    {
+        if (value == null)
+            return null;
+        String normalized = value.trim();
+        return normalized.length() > 0 ? normalized : null;
+    }
+}
 

--- a/src/main/resources/hbci-300.xml
+++ b/src/main/resources/hbci-300.xml
@@ -1372,6 +1372,13 @@
             <DE name="canallaccounts" type="JN"/>
             <DE name="suppformats" type="AN" maxsize="256" maxnum="99" />
         </DEGdef>
+
+        <!-- Proprietary DKKKU/DIKKU extension used by several institutes. -->
+        <DEGdef id="ParKreditkartenUmsatz2">
+            <DE name="timerange" type="Num" maxsize="4"/>
+            <DE name="canmaxentries" type="JN"/>
+            <DE name="canrange" type="JN"/>
+        </DEGdef>
         
         <DEGdef id="CamtBooked">
             <!-- Die erlaubte Maximalanzahl ist nicht spezifiziert. Da steht nur "n" als Anzahl -->
@@ -1806,6 +1813,48 @@
                 <validvalue>C</validvalue>
                 <validvalue>D</validvalue>
             </valids>
+        </DEGdef>
+
+        <!-- Some institutes return a signed value although CreditDebit is
+             already present. Keep the proprietary amount field permissive and
+             normalize it in GVRKreditkartenUmsatz. -->
+        <DEGdef id="KreditkartenSaldo">
+            <DE name="CreditDebit" type="Code" maxsize="1"/>
+            <DE name="value" type="AN" maxsize="32"/>
+            <DE name="curr" type="Cur" minnum="0"/>
+            <DE name="date" type="Date" minnum="0"/>
+            <DE name="time" type="Time" minnum="0"/>
+
+            <valids path="CreditDebit">
+                <validvalue>C</validvalue>
+                <validvalue>D</validvalue>
+            </valids>
+        </DEGdef>
+
+        <DEGdef id="KreditkartenUmsatz">
+            <DE name="cardnumber" type="ID"/>
+            <DE name="bookingdate" type="Date"/>
+            <DE name="valuedate" type="Date"/>
+            <DE name="reference" type="AN" maxsize="2048" minnum="0"/>
+            <DE name="originalvalue" type="AN" maxsize="32" minnum="0"/>
+            <DE name="originalcurrency" type="AN" maxsize="32" minnum="0"/>
+            <DE name="originalcreditdebit" type="AN" maxsize="8" minnum="0"/>
+            <DE name="exchangerate" type="AN" maxsize="32" minnum="0"/>
+            <DE name="value" type="AN" maxsize="32" minnum="0"/>
+            <DE name="currency" type="AN" maxsize="32" minnum="0"/>
+            <DE name="creditdebit" type="AN" maxsize="8" minnum="0"/>
+            <DE name="purpose" type="AN" maxsize="2048" minnum="0"/>
+            <DE name="location" type="AN" maxsize="2048" minnum="0"/>
+            <DE name="detail1" type="AN" maxsize="2048" minnum="0"/>
+            <DE name="detail2" type="AN" maxsize="2048" minnum="0"/>
+            <DE name="detail3" type="AN" maxsize="2048" minnum="0"/>
+            <DE name="detail4" type="AN" maxsize="2048" minnum="0"/>
+            <DE name="detail5" type="AN" maxsize="2048" minnum="0"/>
+            <DE name="detail6" type="AN" maxsize="2048" minnum="0"/>
+            <DE name="detail7" type="AN" maxsize="2048" minnum="0"/>
+            <DE name="finalized" type="AN" maxsize="8" minnum="0"/>
+            <DE name="detail8" type="AN" maxsize="2048" minnum="0"/>
+            <DE name="merchantcategory" type="AN" maxsize="32" minnum="0"/>
         </DEGdef>
         
         <DEGdef id="TAN2StepParams1">
@@ -4620,6 +4669,41 @@
             
             <value path="SegHead.code">HICAZS</value>
             <value path="SegHead.version">1</value>
+        </SEGdef>
+
+        <SEGdef id="KreditkartenUmsatz2">
+            <DEG type="SegHeadUser" name="SegHead"/>
+            <DEG type="KTV2" name="KTV"/>
+            <DE name="cardnumber" type="ID"/>
+            <DE name="cardsubnumber" type="ID" minnum="0"/>
+            <DE name="startdate" type="Date" minnum="0"/>
+            <DE name="enddate" type="Date" minnum="0"/>
+            <DE name="maxentries" type="Num" maxsize="4" minnum="0"/>
+            <DE name="offset" type="AN" maxsize="35" minnum="0"/>
+
+            <value path="SegHead.code">DKKKU</value>
+            <value path="SegHead.version">2</value>
+        </SEGdef>
+        <SEGdef id="KreditkartenUmsatzRes2">
+            <DEG type="SegHeadInst" name="SegHead"/>
+            <DE name="cardnumber" type="ID"/>
+            <DE name="reference" type="AN" maxsize="2048" minnum="0"/>
+            <DEG type="KreditkartenSaldo" name="balance" minnum="0"/>
+            <DE name="detail1" type="AN" maxsize="2048" minnum="0"/>
+            <DE name="detail2" type="AN" maxsize="2048" minnum="0"/>
+            <DEG type="KreditkartenUmsatz" name="transactions" minnum="0" maxnum="999"/>
+
+            <value path="SegHead.code">DIKKU</value>
+            <value path="SegHead.version">2</value>
+        </SEGdef>
+        <SEGdef id="KreditkartenUmsatzPar2">
+            &GVP2;
+            <DEG type="ParKreditkartenUmsatz2" name="ParKreditkartenUmsatz"/>
+
+            &SecClassValids;
+
+            <value path="SegHead.code">DIKKUS</value>
+            <value path="SegHead.version">2</value>
         </SEGdef>
 
         
@@ -8184,6 +8268,7 @@
             <SEG type="KUmsZeit6" minnum="0"/>
             <SEG type="KUmsZeit7" minnum="0"/>
             <SEG type="KUmsZeitCamt1" minnum="0"/>
+            <SEG type="KreditkartenUmsatz2" minnum="0"/>
             <SEG type="Last2" minnum="0"/>
             <SEG type="Last3" minnum="0"/>
             <SEG type="Last4" minnum="0"/>
@@ -8353,6 +8438,7 @@
             <SEG type="KUmsZeitRes6" minnum="0"/>
             <SEG type="KUmsZeitRes7" minnum="0"/>
             <SEG type="KUmsZeitCamtRes1" minnum="0"/>
+            <SEG type="KreditkartenUmsatzRes2" minnum="0"/>
             <SEG type="LastSEPARes1" minnum="0"/>
             <SEG type="LastCOR1SEPARes1" minnum="0"/>
             <SEG type="LastB2BSEPARes1" minnum="0"/>
@@ -8500,6 +8586,7 @@
             <SEG type="KUmsZeitPar6" minnum="0"/>
             <SEG type="KUmsZeitPar7" minnum="0"/>
             <SEG type="KUmsZeitCamtPar1" minnum="0"/>
+            <SEG type="KreditkartenUmsatzPar2" minnum="0"/>
             <SEG type="LastPar2" minnum="0"/>
             <SEG type="LastPar3" minnum="0"/>
             <SEG type="LastPar4" minnum="0"/>

--- a/src/test/java/org/kapott/hbci4java/msg/TestGVRKreditkartenUmsatz.java
+++ b/src/test/java/org/kapott/hbci4java/msg/TestGVRKreditkartenUmsatz.java
@@ -1,0 +1,94 @@
+/**********************************************************************
+ *
+ * This file is part of HBCI4Java.
+ * Copyright (c) 2026 Franz Bettag
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ **********************************************************************/
+
+package org.kapott.hbci4java.msg;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Properties;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.kapott.hbci.GV_Result.GVRKUms.UmsLine;
+import org.kapott.hbci.GV_Result.GVRKreditkartenUmsatz;
+
+/**
+ * Tests fuer die Konvertierung der proprietaeren DIKKU-Umsatzfelder.
+ */
+public class TestGVRKreditkartenUmsatz
+{
+    /**
+     * Prueft Datum, Vorzeichen, Originalbetrag und Beschreibung.
+     */
+    @Test
+    public void testTransaction()
+    {
+        Properties data = new Properties();
+        data.setProperty("tx.bookingdate","2026-05-20");
+        data.setProperty("tx.valuedate","20260519");
+        data.setProperty("tx.reference","test-reference");
+        data.setProperty("tx.originalvalue","12.34");
+        data.setProperty("tx.originalcurrency","USD");
+        data.setProperty("tx.originalcreditdebit","D");
+        data.setProperty("tx.value","10,50");
+        data.setProperty("tx.currency","EUR");
+        data.setProperty("tx.creditdebit","D");
+        data.setProperty("tx.purpose","Test purchase");
+        data.setProperty("tx.location","Test city");
+
+        GVRKreditkartenUmsatz result = new GVRKreditkartenUmsatz();
+        result.addTransaction(data,"tx");
+
+        List<UmsLine> lines = result.getFlatData();
+        Assert.assertEquals(1,lines.size());
+        Assert.assertEquals(0,new BigDecimal("-10.50").compareTo(lines.get(0).value.getBigDecimalValue()));
+        Assert.assertEquals(0,new BigDecimal("-12.34").compareTo(lines.get(0).orig_value.getBigDecimalValue()));
+        Assert.assertEquals("test-reference",lines.get(0).customerref);
+        Assert.assertEquals("Test purchase / Test city",lines.get(0).usage.get(0));
+        Assert.assertTrue(lines.get(0).isCamt);
+    }
+
+    /**
+     * Pflichtfelder muessen vorhanden sein.
+     */
+    @Test(expected=IllegalArgumentException.class)
+    public void testMissingAmount()
+    {
+        Properties data = new Properties();
+        data.setProperty("tx.bookingdate","2026-05-20");
+        data.setProperty("tx.valuedate","2026-05-20");
+        new GVRKreditkartenUmsatz().addTransaction(data,"tx");
+    }
+
+    /**
+     * Ungueltige Kalenderdaten duerfen nicht still normalisiert werden.
+     */
+    @Test(expected=IllegalArgumentException.class)
+    public void testInvalidDate()
+    {
+        Properties data = new Properties();
+        data.setProperty("tx.bookingdate","2026-02-31");
+        data.setProperty("tx.valuedate","2026-02-28");
+        data.setProperty("tx.value","1.00");
+        data.setProperty("tx.currency","EUR");
+        new GVRKreditkartenUmsatz().addTransaction(data,"tx");
+    }
+}

--- a/src/test/java/org/kapott/hbci4java/msg/TestKreditkartenUmsatzSyntax.java
+++ b/src/test/java/org/kapott/hbci4java/msg/TestKreditkartenUmsatzSyntax.java
@@ -1,0 +1,64 @@
+/**********************************************************************
+ *
+ * This file is part of HBCI4Java.
+ * Copyright (c) 2026 Franz Bettag
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ **********************************************************************/
+
+package org.kapott.hbci4java.msg;
+
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.kapott.hbci.manager.HBCIKernelImpl;
+import org.kapott.hbci4java.AbstractTest;
+
+/**
+ * Tests fuer die DKKKU/DIKKU-Syntaxregistrierung.
+ */
+public class TestKreditkartenUmsatzSyntax extends AbstractTest
+{
+    /**
+     * Prueft Parameterreihenfolge, Ergebnisfelder und BPD-Restriktionen.
+     */
+    @Test
+    public void testSyntax()
+    {
+        HBCIKernelImpl kernel = new HBCIKernelImpl(null,"300");
+        Assert.assertTrue(kernel.getAllLowlevelJobs().get("KreditkartenUmsatz").contains("2"));
+
+        List<String> params = kernel.getLowlevelJobParameterNames("KreditkartenUmsatz","2");
+        Assert.assertTrue(params.contains("cardnumber"));
+        Assert.assertTrue(params.contains("cardsubnumber"));
+        Assert.assertTrue(params.indexOf("my.number") < params.indexOf("cardnumber"));
+        Assert.assertTrue(params.indexOf("cardnumber") < params.indexOf("cardsubnumber"));
+        Assert.assertTrue(params.indexOf("cardsubnumber") < params.indexOf("startdate"));
+        Assert.assertTrue(params.indexOf("startdate") < params.indexOf("enddate"));
+        Assert.assertTrue(params.indexOf("enddate") < params.indexOf("maxentries"));
+        Assert.assertTrue(params.indexOf("maxentries") < params.indexOf("offset"));
+
+        List<String> result = kernel.getLowlevelJobResultNames("KreditkartenUmsatz","2");
+        Assert.assertTrue(result.contains("transactions.bookingdate"));
+        Assert.assertTrue(result.contains("transactions.value"));
+
+        List<String> restrictions = kernel.getLowlevelJobRestrictionNames("KreditkartenUmsatz","2");
+        Assert.assertTrue(restrictions.contains("timerange"));
+        Assert.assertTrue(restrictions.contains("canmaxentries"));
+        Assert.assertTrue(restrictions.contains("canrange"));
+    }
+}

--- a/src/test/java/org/kapott/hbci4java/tools/TestStringUtil.java
+++ b/src/test/java/org/kapott/hbci4java/tools/TestStringUtil.java
@@ -68,6 +68,38 @@ public class TestStringUtil
     Assert.assertEquals("foobar",StringUtil.join(Arrays.asList("foo","bar"),null));
   }
 
-}
+  /**
+   * @throws Exception
+   */
+  @Test
+  public void test005() throws Exception
+  {
+    Assert.assertEquals("1234.56",StringUtil.normalizeDecimal("1.234,56"));
+    Assert.assertEquals("1234.56",StringUtil.normalizeDecimal("1234.56"));
+    Assert.assertNull(StringUtil.normalizeDecimal(null));
+  }
 
+  /**
+   * @throws Exception
+   */
+  @Test
+  public void test006() throws Exception
+  {
+    Assert.assertEquals("Purpose / City",StringUtil.joinDescription(" Purpose "," City "));
+    Assert.assertEquals("Purpose",StringUtil.joinDescription("Purpose","purpose"));
+    Assert.assertEquals("City",StringUtil.joinDescription(null," City "));
+  }
+
+  /**
+   * @throws Exception
+   */
+  @Test
+  public void test007() throws Exception
+  {
+    Assert.assertEquals("value",StringUtil.normalize(" value "));
+    Assert.assertNull(StringUtil.normalize("  "));
+    Assert.assertNull(StringUtil.normalize(null));
+  }
+
+}
 


### PR DESCRIPTION
## Zweck

Einige Institute stellen Kreditkartenumsätze nicht über HKKAZ/HKCAZ, sondern über den proprietären Geschäftsvorfall DKKKU/DIKKU bereit. HBCI4Java kannte dessen Syntax bisher nicht, sodass Anwendungen diese Kartenumsätze nicht nativ abrufen konnten.

## Änderungen

- registriert DKKKU, DIKKU und DIKKUS Version 2 in `hbci-300.xml`
- unterstützt Kontoverbindung, Karten-/Unterkartennummer, Von-/Bis-Datum, maximale Eintragszahl und Wiederaufsetzpunkt
- erlaubt Wiederholungen bei Rückmeldung 3040; die bestehende Offset-Logik übernimmt die Folgeseiten
- konvertiert DIKKU-Buchungen in `GVRKUms.UmsLine`, damit bestehende Umsatzverarbeitung weiterverwendet werden kann
- verarbeitet Soll/Haben-Vorzeichen, Originalbetrag, strikte Datumswerte und Buchungsbeschreibung
- ergänzt Highlevel-Dokumentation sowie Syntax- und Parser-Tests

Die Reihenfolge `KTV, cardnumber, cardsubnumber, startdate, enddate, maxentries, offset` und das Antwortformat wurden gegen anonymisierte Live-Antworten eines Sparkassen-FinTS-Zugangs geprüft. Da DKKKU nicht Teil der öffentlichen FinTS-Spezifikation ist, implementiert dieser PR bewusst nur die beobachtete Segmentversion 2.

## Integration

Die zugehörige Hibiscus-Integration liegt in [willuhn/hibiscus#158](https://github.com/willuhn/hibiscus/pull/158).

## Tests

- `./gradlew test`
- `xmllint --noout src/main/resources/hbci-300.xml`

Beide Prüfungen laufen vollständig erfolgreich.