### PR TITLE
LowLevel Job für Statusabfrage von Echtzeitüberweisungen

### DIFF
--- a/src/main/java/org/kapott/hbci/GV/GVInstUebSEPAStatus.java
+++ b/src/main/java/org/kapott/hbci/GV/GVInstUebSEPAStatus.java
@@ -1,0 +1,89 @@
+/**********************************************************************
+ *
+ * This file is part of HBCI4Java.
+ * Copyright (c) 2001-2008 Stefan Palme
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ **********************************************************************/
+
+package org.kapott.hbci.GV;
+
+import java.util.Properties;
+
+import org.kapott.hbci.GV_Result.GVRInstUebSEPAStatus;
+import org.kapott.hbci.manager.HBCIHandler;
+import org.kapott.hbci.manager.LogFilter;
+import org.kapott.hbci.status.HBCIMsgStatus;
+
+/**
+ * Job-Implementierung fuer die Statusabfrage einer SEPA-Instant Ueberweisung.
+ */
+public class GVInstUebSEPAStatus extends HBCIJobImpl<GVRInstUebSEPAStatus>
+{
+    /**
+     * Liefert den Lowlevel-Namen des Jobs.
+     * @return der Lowlevel-Name des Jobs.
+     */
+    public static String getLowlevelName()
+    {
+        return "InstUebSEPAStatus";
+    }
+
+    /**
+     * ct.
+     * @param handler der HBCI-Handler.
+     */
+    public GVInstUebSEPAStatus(HBCIHandler handler)
+    {
+        super(handler, getLowlevelName(), new GVRInstUebSEPAStatus());
+
+        addConstraint("src.bic", "My.bic", null, LogFilter.FILTER_MOST);
+        addConstraint("src.iban", "My.iban", null, LogFilter.FILTER_IDS);
+
+        if (canNationalAcc(handler))
+        {
+            addConstraint("src.country", "My.KIK.country", "", LogFilter.FILTER_NONE);
+            addConstraint("src.blz", "My.KIK.blz", "", LogFilter.FILTER_MOST);
+            addConstraint("src.number", "My.number", "", LogFilter.FILTER_IDS);
+            addConstraint("src.subnumber", "My.subnumber", "", LogFilter.FILTER_MOST);
+        }
+
+        addConstraint("format", "formats.format", null, LogFilter.FILTER_NONE, true);
+        addConstraint("orderid", "orderid", null, LogFilter.FILTER_NONE);
+    }
+
+    /**
+     * @see org.kapott.hbci.GV.HBCIJobImpl#extractResults(org.kapott.hbci.status.HBCIMsgStatus, java.lang.String, int)
+     */
+    @Override
+    protected void extractResults(HBCIMsgStatus msgstatus, String header, int idx)
+    {
+        Properties data = msgstatus.getData();
+        jobResult.setOrderId(data.getProperty(header + ".orderid"));
+        jobResult.setOrderStatus(data.getProperty(header + ".orderstatus"));
+        jobResult.setCancellationCode(data.getProperty(header + ".ccode"));
+    }
+
+    /**
+     * @see org.kapott.hbci.GV.HBCIJobImpl#verifyConstraints()
+     */
+    @Override
+    public void verifyConstraints()
+    {
+        super.verifyConstraints();
+        checkAccountCRC("src");
+    }
+}

--- a/src/main/java/org/kapott/hbci/GV_Result/GVRInstUebSEPAStatus.java
+++ b/src/main/java/org/kapott/hbci/GV_Result/GVRInstUebSEPAStatus.java
@@ -1,0 +1,98 @@
+/**********************************************************************
+ *
+ * This file is part of HBCI4Java.
+ * Copyright (c) 2001-2008 Stefan Palme
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ **********************************************************************/
+
+package org.kapott.hbci.GV_Result;
+
+/**
+ * Rueckgabedaten fuer die Statusabfrage einer SEPA-Instant Ueberweisung.
+ */
+public class GVRInstUebSEPAStatus extends HBCIJobResultImpl
+{
+    private static final long serialVersionUID = 1L;
+
+    private String orderId;
+    private String orderStatus;
+    private String cancellationCode;
+
+    /**
+     * Liefert die Auftrags-ID der Echtzeitueberweisung.
+     * @return die Auftrags-ID.
+     */
+    public String getOrderId()
+    {
+        return orderId;
+    }
+
+    /**
+     * Speichert die Auftrags-ID der Echtzeitueberweisung.
+     * @param orderId die Auftrags-ID.
+     */
+    public void setOrderId(String orderId)
+    {
+        this.orderId = orderId;
+    }
+
+    /**
+     * Liefert den Auftragsstatus.
+     * @return der Auftragsstatus.
+     */
+    public String getOrderStatus()
+    {
+        return orderStatus;
+    }
+
+    /**
+     * Speichert den Auftragsstatus.
+     * @param orderStatus der Auftragsstatus.
+     */
+    public void setOrderStatus(String orderStatus)
+    {
+        this.orderStatus = orderStatus;
+    }
+
+    /**
+     * Liefert den Rueckgabecode zur Nichtausfuehrung.
+     * @return der Rueckgabecode oder {@code null}.
+     */
+    public String getCancellationCode()
+    {
+        return cancellationCode;
+    }
+
+    /**
+     * Speichert den Rueckgabecode zur Nichtausfuehrung.
+     * @param cancellationCode der Rueckgabecode.
+     */
+    public void setCancellationCode(String cancellationCode)
+    {
+        this.cancellationCode = cancellationCode;
+    }
+
+    /**
+     * @see java.lang.Object#toString()
+     */
+    @Override
+    public String toString()
+    {
+        return String.format("GVRInstUebSEPAStatus{orderId=%s, orderStatus=%s, cancellationCode=%s}",
+            orderId, orderStatus, cancellationCode);
+    }
+}

--- a/src/main/resources/hbci-300.xml
+++ b/src/main/resources/hbci-300.xml
@@ -1515,6 +1515,15 @@
             <DE name="suppformats" type="AN" maxsize="256" minnum="0" maxnum="9"/>
         </DEGdef>
         
+        <DEGdef id="SuppSepaPainMessages">
+            <DE name="format" type="AN" maxsize="256" maxnum="99"/>
+        </DEGdef>
+
+        <DEGdef id="ParInstUebSEPAStatus">
+            <DE name="minwait" type="Num" maxsize="2"/>
+            <DE name="suppformats" type="AN" maxsize="256" minnum="0" maxnum="9"/>
+        </DEGdef>
+
 
         <DEGdef id="ParTAN2Step1">
             <DE name="can1step" type="JN"/>
@@ -6721,6 +6730,58 @@
             <value path="SegHead.code">HIIPZS</value>
             <value path="SegHead.version">1</value>
         </SEGdef>
+
+        <!-- BEGIN SEPA-Instant Payment Status -->
+        <SEGdef id="InstUebSEPAStatus1">
+            <DEG type="SegHeadUser" name="SegHead"/>
+            <DEG type="KTVInt" name="My"/>
+            <DEG type="SuppSepaPainMessages" name="formats"/>
+            <DE name="orderid" type="AN" maxsize="99"/>
+
+            <value path="SegHead.code">HKIPS</value>
+            <value path="SegHead.version">1</value>
+        </SEGdef>
+
+        <SEGdef id="InstUebSEPAStatusRes1">
+            <DEG type="SegHeadInst" name="SegHead"/>
+            <DEG type="KTVInt" name="My"/>
+            <DE name="sepadescr" type="AN" maxsize="256" minnum="0"/>
+            <DE name="sepapain" type="Bin" maxsize="0" minnum="0"/>
+            <DE name="orderid" type="AN" maxsize="99"/>
+            <DE name="ccode" type="Code" maxsize="1" minnum="0"/>
+            <DE name="orderstatus" type="Code" maxsize="1" minnum="0"/>
+
+            <valids path="ccode">
+                <validvalue>1</validvalue>
+                <validvalue>2</validvalue>
+                <validvalue>3</validvalue>
+                <validvalue>4</validvalue>
+            </valids>
+            <valids path="orderstatus">
+                <validvalue>1</validvalue>
+                <validvalue>2</validvalue>
+                <validvalue>3</validvalue>
+                <validvalue>4</validvalue>
+                <validvalue>5</validvalue>
+                <validvalue>6</validvalue>
+                <validvalue>7</validvalue>
+                <validvalue>8</validvalue>
+                <validvalue>9</validvalue>
+            </valids>
+
+            <value path="SegHead.code">HIIPS</value>
+            <value path="SegHead.version">1</value>
+        </SEGdef>
+
+        <SEGdef id="InstUebSEPAStatusPar1">
+            &GVP2;
+            <DEG type="ParInstUebSEPAStatus"/>
+            &SecClassValids;
+
+            <value path="SegHead.code">HIIPSS</value>
+            <value path="SegHead.version">1</value>
+        </SEGdef>
+        <!-- END SEPA-Instant Payment Status -->
         <!-- END SEPA-Instant aka 'SEPA-Instant Payment Zahlung' -->
 
         <!-- BEGIN SEPA-Umbuchung aka 'SEPA-Überweisung auf ein Empfängerkonto' -->
@@ -8168,6 +8229,7 @@
             <SEG type="InfoList3" minnum="0"/>
             <SEG type="InfoList4" minnum="0"/>
             <SEG type="InstUebSEPA1" minnum="0"/>
+            <SEG type="InstUebSEPAStatus1" minnum="0"/>
             <SEG type="Kontoauszug1" minnum="0"/>
             <SEG type="Kontoauszug2" minnum="0"/>
             <SEG type="Kontoauszug3" minnum="0"/>
@@ -8337,6 +8399,7 @@
             <SEG type="InfoListRes3" minnum="0"/>
             <SEG type="InfoListRes4" minnum="0"/>
             <SEG type="InstUebSEPARes1" minnum="0"/>
+            <SEG type="InstUebSEPAStatusRes1" minnum="0"/>
             <SEG type="KontoauszugRes1" minnum="0"/>
             <SEG type="KontoauszugRes2" minnum="0"/>
             <SEG type="KontoauszugRes3" minnum="0"/>
@@ -8484,6 +8547,7 @@
             <SEG type="InfoListPar3" minnum="0"/>
             <SEG type="InfoListPar4" minnum="0"/>
             <SEG type="InstUebSEPAPar1" minnum="0"/>
+            <SEG type="InstUebSEPAStatusPar1" minnum="0"/>
             <SEG type="KontoauszugPar1" minnum="0"/>
             <SEG type="KontoauszugPar2" minnum="0"/>
             <SEG type="KontoauszugPar3" minnum="0"/>

--- a/src/test/java/org/kapott/hbci/GV/GVInstUebSEPAStatusTest.java
+++ b/src/test/java/org/kapott/hbci/GV/GVInstUebSEPAStatusTest.java
@@ -1,0 +1,79 @@
+package org.kapott.hbci.GV;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Properties;
+
+import org.junit.Test;
+import org.kapott.hbci.GV_Result.GVRInstUebSEPAStatus;
+import org.kapott.hbci.manager.HBCIHandler;
+import org.kapott.hbci.passport.HBCIPassportPinTan;
+import org.kapott.hbci.status.HBCIMsgStatus;
+import org.kapott.hbci.structures.Konto;
+import org.kapott.hbci4java.AbstractTest;
+
+public class GVInstUebSEPAStatusTest extends AbstractTest
+{
+    private static final String FORMAT = "urn:iso:std:iso:20022:tech:xsd:pain.001.001.09";
+
+    @Test
+    public void testHighlevelJob()
+    {
+        try (HBCIHandler handler = createHandler())
+        {
+            HBCIJob<?> genericJob = handler.newJob("InstUebSEPAStatus");
+            assertTrue(genericJob instanceof GVInstUebSEPAStatus);
+
+            GVInstUebSEPAStatus job = (GVInstUebSEPAStatus) genericJob;
+            assertEquals("HKIPS", job.getHBCICode());
+            assertTrue(job.getJobResult() instanceof GVRInstUebSEPAStatus);
+
+            Konto account = new Konto();
+            account.iban = "DE89370400440532013000";
+            account.bic = "COBADEFFXXX";
+            job.setParam("src", account);
+            job.setParam("format", FORMAT);
+            job.setParam("orderid", "ORDER-123");
+            job.verifyConstraints();
+
+            Properties params = job.getLowlevelParams();
+            assertEquals(account.iban, params.getProperty("InstUebSEPAStatus1.My.iban"));
+            assertEquals(account.bic, params.getProperty("InstUebSEPAStatus1.My.bic"));
+            assertEquals(FORMAT, params.getProperty("InstUebSEPAStatus1.formats.format"));
+            assertEquals("ORDER-123", params.getProperty("InstUebSEPAStatus1.orderid"));
+        }
+    }
+
+    @Test
+    public void testResultExtraction()
+    {
+        try (HBCIHandler handler = createHandler())
+        {
+            GVInstUebSEPAStatus job = (GVInstUebSEPAStatus) handler.newJob("InstUebSEPAStatus");
+            Properties data = new Properties();
+            data.setProperty("GVRes.orderid", "ORDER-123");
+            data.setProperty("GVRes.orderstatus", "7");
+            data.setProperty("GVRes.ccode", "2");
+
+            HBCIMsgStatus status = new HBCIMsgStatus();
+            status.setData(data);
+            job.extractResults(status, "GVRes", 0);
+
+            GVRInstUebSEPAStatus result = job.getJobResult();
+            assertEquals("ORDER-123", result.getOrderId());
+            assertEquals("7", result.getOrderStatus());
+            assertEquals("2", result.getCancellationCode());
+        }
+    }
+
+    private static HBCIHandler createHandler()
+    {
+        HBCIPassportPinTan passport = new HBCIPassportPinTan(null, 0);
+        Properties bpd = new Properties();
+        bpd.setProperty("Params.InstUebSEPAStatusPar1.SegHead.code", "HIIPSS");
+        passport.setBPD(bpd);
+        passport.setHBCIVersion("300");
+        return new HBCIHandler("300", passport, true);
+    }
+}

--- a/src/test/java/org/kapott/hbci4java/msg/TestInstUebSEPAStatus.java
+++ b/src/test/java/org/kapott/hbci4java/msg/TestInstUebSEPAStatus.java
@@ -1,0 +1,36 @@
+package org.kapott.hbci4java.msg;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.kapott.hbci.manager.HBCIKernelImpl;
+import org.kapott.hbci.manager.MsgGen;
+import org.kapott.hbci4java.AbstractTest;
+
+public class TestInstUebSEPAStatus extends AbstractTest
+{
+  @Test
+  public void testLowlevelSyntax()
+  {
+    MsgGen generator = new HBCIKernelImpl(null, "300").getMsgGen();
+
+    assertEquals(List.of("1"), generator.getLowlevelGVs().get("InstUebSEPAStatus"));
+    assertContains(generator.getGVParameterNames("InstUebSEPAStatus", "1"),
+        "My.iban", "My.bic", "formats.format", "orderid");
+    assertContains(generator.getGVResultNames("InstUebSEPAStatus", "1"),
+        "My.iban", "sepadescr", "sepapain", "orderid", "ccode", "orderstatus");
+    assertContains(generator.getGVRestrictionNames("InstUebSEPAStatus", "1"),
+        "minwait", "suppformats");
+  }
+
+  private static void assertContains(List<String> actual, String... expected)
+  {
+    for (String value : expected)
+    {
+      assertTrue("Missing lowlevel field " + value + " in " + actual, actual.contains(value));
+    }
+  }
+}


### PR DESCRIPTION
Wenn ich nichts übersehen habe, dann unterstützt die FinTS-Syntax von HBCI4Java bislang zwar Echtzeitüberweisungen, aber noch nicht die zugehörige Statusabfrage.

Die Änderung ergänzt HKIPS, HIIPS und HIIPSS einschließlich Auftrags-ID, unterstützter pain-Nachrichten, Rückgabecode und Auftragsstatus. Dadurch kann die Statusabfrage über die bestehende Low-Level-API verwendet werden.

Ein Unit-Test prüft, dass der Geschäftsvorfall und seine Request-, Response- und BPD-Felder vollständig in der FinTS-3.0-Syntax verfügbar sind.