### PR TITLE
High Level Job für die Kontoauszugsübersicht (HKKAU)

### DIFF
--- a/src/main/java/org/kapott/hbci/GV/GVKontoauszugUebersicht.java
+++ b/src/main/java/org/kapott/hbci/GV/GVKontoauszugUebersicht.java
@@ -1,0 +1,73 @@
+/**********************************************************************
+ *
+ * This file is part of HBCI4Java.
+ * Copyright (c) 2026 HBCI4Java contributors
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ *
+ **********************************************************************/
+
+package org.kapott.hbci.GV;
+
+import org.kapott.hbci.GV_Result.HBCIJobResultImpl;
+import org.kapott.hbci.manager.HBCIHandler;
+import org.kapott.hbci.manager.LogFilter;
+
+/**
+ * Implementierung des Geschaeftsvorfalls zum Abruf der Kontoauszugsuebersicht (HKKAU).
+ */
+public class GVKontoauszugUebersicht extends HBCIJobImpl<HBCIJobResultImpl>
+{
+    /**
+     * Liefert den Lowlevel-Namen.
+     * @return der Lowlevel-Name.
+     */
+    public static String getLowlevelName()
+    {
+        return "KontoauszugUebersicht";
+    }
+
+    /**
+     * ct.
+     * @param handler der Handler.
+     */
+    public GVKontoauszugUebersicht(HBCIHandler handler)
+    {
+        super(handler, getLowlevelName(), new HBCIJobResultImpl());
+
+        addConstraint("my.bic", "My.bic", "", LogFilter.FILTER_MOST);
+        addConstraint("my.iban", "My.iban", "", LogFilter.FILTER_IDS);
+
+        if (this.canNationalAcc(handler))
+        {
+            addConstraint("my.country", "My.KIK.country", "DE", LogFilter.FILTER_NONE);
+            addConstraint("my.blz", "My.KIK.blz", "", LogFilter.FILTER_MOST);
+            addConstraint("my.number", "My.number", "", LogFilter.FILTER_IDS);
+            addConstraint("my.subnumber", "My.subnumber", "", LogFilter.FILTER_MOST);
+        }
+
+        addConstraint("maxentries", "maxentries", "", LogFilter.FILTER_NONE);
+        addConstraint("offset", "offset", "", LogFilter.FILTER_NONE);
+    }
+
+    /**
+     * @see org.kapott.hbci.GV.HBCIJobImpl#redoAllowed()
+     */
+    @Override
+    protected boolean redoAllowed()
+    {
+        return true;
+    }
+}

--- a/src/main/resources/hbci-300.xml
+++ b/src/main/resources/hbci-300.xml
@@ -4099,6 +4099,97 @@
             <value path="SegHead.version">4</value>
         </SEGdef>
         
+        <SEGdef id="KontoauszugUebersicht1">
+            <DEG type="SegHeadUser" name="SegHead"/>
+            <DEG type="KTV3" name="My"/>
+            <DE name="maxentries" type="Num" maxsize="4" minnum="0"/>
+            <DE name="offset" type="AN" maxsize="35" minnum="0"/>
+
+            <value path="SegHead.code">HKKAU</value>
+            <value path="SegHead.version">1</value>
+        </SEGdef>
+        <SEGdef id="KontoauszugUebersichtRes1">
+            <DEG type="SegHeadInst" name="SegHead"/>
+            <DE name="number" type="Num" maxsize="5"/>
+            <DE name="acknowledgement" type="Code" maxsize="1"/>
+            <DE name="retrievable" type="JN"/>
+            <DE name="year" type="Num" maxsize="4" minnum="0"/>
+            <DE name="date" type="Date" minnum="0"/>
+            <DE name="time" type="Time" minnum="0"/>
+            <DE name="creationtype" type="AN" maxsize="30" minnum="0"/>
+
+            <value path="SegHead.code">HIKAU</value>
+            <value path="SegHead.version">1</value>
+        </SEGdef>
+        <SEGdef id="KontoauszugUebersichtPar1">
+            &GVP2;
+            &SecClassValids;
+
+            <value path="SegHead.code">HIKAUS</value>
+            <value path="SegHead.version">1</value>
+        </SEGdef>
+
+        <SEGdef id="KontoauszugUebersicht2">
+            <DEG type="SegHeadUser" name="SegHead"/>
+            <DEG type="KTVInt" name="My"/>
+            <DE name="maxentries" type="Num" maxsize="4" minnum="0"/>
+            <DE name="offset" type="AN" maxsize="35" minnum="0"/>
+
+            <value path="SegHead.code">HKKAU</value>
+            <value path="SegHead.version">2</value>
+        </SEGdef>
+        <SEGdef id="KontoauszugUebersichtRes2">
+            <DEG type="SegHeadInst" name="SegHead"/>
+            <DE name="number" type="Num" maxsize="5"/>
+            <DE name="acknowledgement" type="Code" maxsize="1"/>
+            <DE name="retrievable" type="JN"/>
+            <DE name="year" type="Num" maxsize="4" minnum="0"/>
+            <DE name="date" type="Date" minnum="0"/>
+            <DE name="time" type="Time" minnum="0"/>
+            <DE name="creationtype" type="AN" maxsize="30" minnum="0"/>
+
+            <value path="SegHead.code">HIKAU</value>
+            <value path="SegHead.version">2</value>
+        </SEGdef>
+        <SEGdef id="KontoauszugUebersichtPar2">
+            &GVP2;
+            &SecClassValids;
+
+            <value path="SegHead.code">HIKAUS</value>
+            <value path="SegHead.version">2</value>
+        </SEGdef>
+
+        <SEGdef id="KontoauszugUebersicht3">
+            <DEG type="SegHeadUser" name="SegHead"/>
+            <DEG type="KTVInt" name="My"/>
+            <DE name="maxentries" type="Num" maxsize="4" minnum="0"/>
+            <DE name="offset" type="AN" maxsize="35" minnum="0"/>
+
+            <value path="SegHead.code">HKKAU</value>
+            <value path="SegHead.version">3</value>
+        </SEGdef>
+        <SEGdef id="KontoauszugUebersichtRes3">
+            <DEG type="SegHeadInst" name="SegHead"/>
+            <DE name="number" type="Num" maxsize="5" minnum="0"/>
+            <DE name="acknowledgement" type="Code" maxsize="1"/>
+            <DE name="retrievable" type="JN"/>
+            <DE name="year" type="Num" maxsize="4" minnum="0"/>
+            <DE name="date" type="Date" minnum="0"/>
+            <DE name="time" type="Time" minnum="0"/>
+            <DE name="creationtype" type="AN" maxsize="30" minnum="0"/>
+            <DE name="documentid" type="AN" maxsize="256" minnum="0"/>
+
+            <value path="SegHead.code">HIKAU</value>
+            <value path="SegHead.version">3</value>
+        </SEGdef>
+        <SEGdef id="KontoauszugUebersichtPar3">
+            &GVP2;
+            &SecClassValids;
+
+            <value path="SegHead.code">HIKAUS</value>
+            <value path="SegHead.version">3</value>
+        </SEGdef>
+
         <SEGdef id="Kontoauszug1">
             <DEG type="SegHeadUser" name="SegHead"/>
             <DEG type="KTV3" name="My"/>
@@ -8168,6 +8259,9 @@
             <SEG type="InfoList3" minnum="0"/>
             <SEG type="InfoList4" minnum="0"/>
             <SEG type="InstUebSEPA1" minnum="0"/>
+            <SEG type="KontoauszugUebersicht1" minnum="0"/>
+            <SEG type="KontoauszugUebersicht2" minnum="0"/>
+            <SEG type="KontoauszugUebersicht3" minnum="0"/>
             <SEG type="Kontoauszug1" minnum="0"/>
             <SEG type="Kontoauszug2" minnum="0"/>
             <SEG type="Kontoauszug3" minnum="0"/>
@@ -8337,6 +8431,9 @@
             <SEG type="InfoListRes3" minnum="0"/>
             <SEG type="InfoListRes4" minnum="0"/>
             <SEG type="InstUebSEPARes1" minnum="0"/>
+            <SEG type="KontoauszugUebersichtRes1" minnum="0"/>
+            <SEG type="KontoauszugUebersichtRes2" minnum="0"/>
+            <SEG type="KontoauszugUebersichtRes3" minnum="0"/>
             <SEG type="KontoauszugRes1" minnum="0"/>
             <SEG type="KontoauszugRes2" minnum="0"/>
             <SEG type="KontoauszugRes3" minnum="0"/>
@@ -8484,6 +8581,9 @@
             <SEG type="InfoListPar3" minnum="0"/>
             <SEG type="InfoListPar4" minnum="0"/>
             <SEG type="InstUebSEPAPar1" minnum="0"/>
+            <SEG type="KontoauszugUebersichtPar1" minnum="0"/>
+            <SEG type="KontoauszugUebersichtPar2" minnum="0"/>
+            <SEG type="KontoauszugUebersichtPar3" minnum="0"/>
             <SEG type="KontoauszugPar1" minnum="0"/>
             <SEG type="KontoauszugPar2" minnum="0"/>
             <SEG type="KontoauszugPar3" minnum="0"/>

--- a/src/test/java/org/kapott/hbci4java/msg/TestKontoauszugUebersicht.java
+++ b/src/test/java/org/kapott/hbci4java/msg/TestKontoauszugUebersicht.java
@@ -1,0 +1,36 @@
+package org.kapott.hbci4java.msg;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+
+import org.junit.Test;
+import org.kapott.hbci.manager.HBCIKernelImpl;
+import org.kapott.hbci.manager.MsgGen;
+import org.kapott.hbci4java.AbstractTest;
+
+public class TestKontoauszugUebersicht extends AbstractTest
+{
+    @Test
+    public void testLowlevelSyntax()
+    {
+        MsgGen generator = new HBCIKernelImpl(null, "300").getMsgGen();
+
+        assertEquals(List.of("1", "2", "3"), generator.getLowlevelGVs().get("KontoauszugUebersicht"));
+        assertContains(generator.getGVParameterNames("KontoauszugUebersicht", "1"),
+            "My.number", "maxentries", "offset");
+        assertContains(generator.getGVParameterNames("KontoauszugUebersicht", "2"),
+            "My.iban", "My.bic", "maxentries", "offset");
+        assertContains(generator.getGVResultNames("KontoauszugUebersicht", "3"), "number", "acknowledgement",
+            "retrievable", "year", "date", "time", "creationtype", "documentid");
+    }
+
+    private static void assertContains(List<String> actual, String... expected)
+    {
+        for (String value : expected)
+        {
+            assertTrue("Missing lowlevel field " + value + " in " + actual, actual.contains(value));
+        }
+    }
+}


### PR DESCRIPTION
Diese Änderung ergänzt die FinTS-Syntax für die Segmentversionen 1 bis 3 und stellt den neuen Geschäftsvorfall als GVKontoauszugUebersicht bereit. Nationale Kontodaten sowie IBAN und BIC werden abhängig von der unterstützten Segmentversion berücksichtigt.

Ein Unit-Test prüft die verfügbaren Segmentversionen sowie die Request- und Response-Felder der neuen Low-Level-Syntax.